### PR TITLE
Add OCR recipe importer

### DIFF
--- a/Cookle/Sources/OCR/Model/OCRRecipeImporter.swift
+++ b/Cookle/Sources/OCR/Model/OCRRecipeImporter.swift
@@ -1,0 +1,32 @@
+//
+//  OCRRecipeImporter.swift
+//  Cookle
+//
+//  Created by Codex on 2025/06/07.
+//
+
+import SwiftData
+
+enum OCRRecipeImporter {
+    static func createRecipe(context: ModelContext, from data: Data) throws -> Recipe {
+        let strings = try PhotoOCR.recognize(from: data)
+        let text = strings.joined(separator: "\n")
+        let parsed = RecipeTextParser.parse(text)
+        return Recipe.create(
+            context: context,
+            name: parsed.name,
+            photos: [],
+            servingSize: .zero,
+            cookingTime: .zero,
+            ingredients: parsed.ingredients.enumerated().map { index, element in
+                .create(context: context,
+                        ingredient: element.ingredient,
+                        amount: element.amount,
+                        order: index + 1)
+            },
+            steps: parsed.steps,
+            categories: [],
+            note: ""
+        )
+    }
+}

--- a/Cookle/Sources/OCR/Model/PhotoOCR.swift
+++ b/Cookle/Sources/OCR/Model/PhotoOCR.swift
@@ -1,0 +1,21 @@
+//
+//  PhotoOCR.swift
+//  Cookle
+//
+//  Created by Codex on 2025/06/05.
+//
+
+import UIKit
+import Vision
+
+enum PhotoOCR {
+    static func recognize(from data: Data) throws -> [String] {
+        guard let image = UIImage(data: data)?.cgImage else {
+            return []
+        }
+        let request = VNRecognizeTextRequest()
+        let handler = VNImageRequestHandler(cgImage: image)
+        try handler.perform([request])
+        return request.results?.compactMap { $0.topCandidates(1).first?.string } ?? []
+    }
+}

--- a/Cookle/Sources/OCR/Model/RecipeTextParser.swift
+++ b/Cookle/Sources/OCR/Model/RecipeTextParser.swift
@@ -1,0 +1,73 @@
+//
+//  RecipeTextParser.swift
+//  Cookle
+//
+//  Created by Codex on 2025/06/07.
+//
+
+import Foundation
+
+struct RecipeText {
+    var name: String
+    var ingredients: [RecipeFormIngredient]
+    var steps: [String]
+}
+
+enum RecipeTextParser {
+    static func parse(_ text: String) -> RecipeText {
+        let lines = text
+            .split(whereSeparator: \._isNewline)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        guard let first = lines.first else {
+            return .init(name: "", ingredients: [], steps: [])
+        }
+
+        var name = first
+        var ingredients = [RecipeFormIngredient]()
+        var steps = [String]()
+
+        var mode: Mode = .unknown
+        for line in lines.dropFirst() {
+            let lower = line.lowercased()
+            if lower.contains("ingredients") || line.contains("材料") {
+                mode = .ingredients
+                continue
+            }
+            if lower.contains("steps") || lower.contains("directions") || line.contains("作り方") {
+                mode = .steps
+                continue
+            }
+            switch mode {
+            case .ingredients:
+                let parts = line.split(separator: " ", maxSplits: 1)
+                if parts.count == 2 {
+                    ingredients.append((String(parts[0]), String(parts[1])))
+                } else if let separatorIndex = line.firstIndex(of: "：") ?? line.firstIndex(of: ":") {
+                    let ing = line[..<separatorIndex]
+                    let amt = line[line.index(after: separatorIndex)...]
+                    ingredients.append((String(ing).trimmingCharacters(in: .whitespaces), String(amt).trimmingCharacters(in: .whitespaces)))
+                } else {
+                    ingredients.append((line, ""))
+                }
+            case .steps:
+                steps.append(line)
+            case .unknown:
+                steps.append(line)
+            }
+        }
+
+        if steps.isEmpty {
+            steps = Array(lines.dropFirst())
+        }
+
+        return .init(name: name, ingredients: ingredients, steps: steps)
+    }
+
+    private enum Mode {
+        case unknown
+        case ingredients
+        case steps
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Cookle is a lightweight recipe manager built entirely with SwiftUI. This reposit
 - App Shortcuts for search, showing the last opened recipe and more
 - Optional iCloud synchronisation and subscription support
 - Google Mobile Ads integration
+- Create recipes from photos using OCR
 
 ## Development
 


### PR DESCRIPTION
## Summary
- create parser to split OCR text into name, ingredients and steps
- add OCRRecipeImporter for turning photo text into a recipe
- document OCR-based recipe creation

## Testing
- `pre-commit run --files README.md Cookle/Sources/OCR/Model/PhotoOCR.swift Cookle/Sources/OCR/Model/RecipeTextParser.swift Cookle/Sources/OCR/Model/OCRRecipeImporter.swift` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437747b55c832080b52de377f12512