### PR TITLE
Separate form views from navigation wrappers

### DIFF
--- a/Cookle/Sources/Diary/View/DiaryFormNavigationView.swift
+++ b/Cookle/Sources/Diary/View/DiaryFormNavigationView.swift
@@ -1,129 +1,13 @@
-//
-//  DiaryFormNavigationView.swift
-//  Cookle
-//
-//  Created by Hiromu Nakano on 2024/04/17.
-//
-
-import SwiftData
 import SwiftUI
 
 struct DiaryFormNavigationView: View {
-    @Environment(\.modelContext) private var context
-    @Environment(\.dismiss) private var dismiss
-
-    @Environment(Diary.self) private var diary: Diary?
-
-    @State private var date = Date.now
-    @State private var breakfasts = Set<Recipe>()
-    @State private var lunches = Set<Recipe>()
-    @State private var dinners = Set<Recipe>()
-    @State private var note = ""
-
     var body: some View {
         NavigationStack {
-            Form {
-                Section {
-                    DatePicker("Date", selection: $date, displayedComponents: .date)
-                        .datePickerStyle(.graphical)
-                }
-                Section {
-                    NavigationLink(value: DiaryObjectType.breakfast) {
-                        Text(DiaryObjectType.breakfast.title)
-                    }
-                } footer: {
-                    Text(breakfasts.map(\.name).joined(separator: ", "))
-                }
-                Section {
-                    NavigationLink(value: DiaryObjectType.lunch) {
-                        Text(DiaryObjectType.lunch.title)
-                    }
-                } footer: {
-                    Text(lunches.map(\.name).joined(separator: ", "))
-                }
-                Section {
-                    NavigationLink(value: DiaryObjectType.dinner) {
-                        Text(DiaryObjectType.dinner.title)
-                    }
-                } footer: {
-                    Text(dinners.map(\.name).joined(separator: ", "))
-                }
-                Section {
-                    TextField(text: $note, axis: .vertical) {
-                        Text("Classic spaghetti carbonara and warm beef stew for a comforting end to the day.")
-                    }
-                } header: {
-                    Text("Note")
-                }
-            }
-            .navigationDestination(for: DiaryObjectType.self) { type in
-                switch type {
-                case .breakfast:
-                    DiaryFormRecipeListView(selection: $breakfasts, type: type)
-                case .lunch:
-                    DiaryFormRecipeListView(selection: $lunches, type: type)
-                case .dinner:
-                    DiaryFormRecipeListView(selection: $dinners, type: type)
-                }
-            }
-            .navigationTitle(Text("Diary"))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("Cancel")
-                    }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        if let diary {
-                            diary.update(
-                                date: date,
-                                objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
-                                    .create(context: context, recipe: element, type: .breakfast, order: index + 1)
-                                } + zip(Array(lunches).indices, lunches).map { index, element in
-                                    .create(context: context, recipe: element, type: .lunch, order: index + 1)
-                                } + zip(Array(dinners).indices, dinners).map { index, element in
-                                    .create(context: context, recipe: element, type: .dinner, order: index + 1)
-                                },
-                                note: note
-                            )
-                        } else {
-                            _ = Diary.create(
-                                context: context,
-                                date: date,
-                                objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
-                                    .create(context: context, recipe: element, type: .breakfast, order: index + 1)
-                                } + zip(Array(lunches).indices, lunches).map { index, element in
-                                    .create(context: context, recipe: element, type: .lunch, order: index + 1)
-                                } + zip(Array(dinners).indices, dinners).map { index, element in
-                                    .create(context: context, recipe: element, type: .dinner, order: index + 1)
-                                },
-                                note: note
-                            )
-                        }
-                        dismiss()
-                    } label: {
-                        Text(diary != nil ? "Update" : "Add")
-                    }
-                    .disabled(breakfasts.isEmpty && lunches.isEmpty && dinners.isEmpty)
-                }
-            }
-        }
-        .interactiveDismissDisabled()
-        .task {
-            date = diary?.date ?? .now
-            breakfasts = .init(diary?.objects.orEmpty.filter { $0.type == .breakfast }.sorted().compactMap(\.recipe) ?? [])
-            lunches = .init(diary?.objects.orEmpty.filter { $0.type == .lunch }.sorted().compactMap(\.recipe) ?? [])
-            dinners = .init(diary?.objects.orEmpty.filter { $0.type == .dinner }.sorted().compactMap(\.recipe) ?? [])
-            note = diary?.note ?? ""
+            DiaryFormView()
         }
     }
 }
 
 #Preview {
-    CooklePreview { _ in
-        DiaryFormNavigationView()
-    }
+    DiaryFormNavigationView()
 }

--- a/Cookle/Sources/Diary/View/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/View/DiaryFormView.swift
@@ -54,60 +54,59 @@ struct DiaryFormView: View {
             } header: {
                 Text("Note")
             }
+        }
+        .navigationDestination(for: DiaryObjectType.self) { type in
+            switch type {
+            case .breakfast:
+                DiaryFormRecipeListView(selection: $breakfasts, type: type)
+            case .lunch:
+                DiaryFormRecipeListView(selection: $lunches, type: type)
+            case .dinner:
+                DiaryFormRecipeListView(selection: $dinners, type: type)
             }
-            .navigationDestination(for: DiaryObjectType.self) { type in
-                switch type {
-                case .breakfast:
-                    DiaryFormRecipeListView(selection: $breakfasts, type: type)
-                case .lunch:
-                    DiaryFormRecipeListView(selection: $lunches, type: type)
-                case .dinner:
-                    DiaryFormRecipeListView(selection: $dinners, type: type)
+        }
+        .navigationTitle(Text("Diary"))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Cancel")
                 }
             }
-            .navigationTitle(Text("Diary"))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("Cancel")
+            ToolbarItem(placement: .confirmationAction) {
+                Button {
+                    if let diary {
+                        diary.update(
+                            date: date,
+                            objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
+                                .create(context: context, recipe: element, type: .breakfast, order: index + 1)
+                            } + zip(Array(lunches).indices, lunches).map { index, element in
+                                .create(context: context, recipe: element, type: .lunch, order: index + 1)
+                            } + zip(Array(dinners).indices, dinners).map { index, element in
+                                .create(context: context, recipe: element, type: .dinner, order: index + 1)
+                            },
+                            note: note
+                        )
+                    } else {
+                        _ = Diary.create(
+                            context: context,
+                            date: date,
+                            objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
+                                .create(context: context, recipe: element, type: .breakfast, order: index + 1)
+                            } + zip(Array(lunches).indices, lunches).map { index, element in
+                                .create(context: context, recipe: element, type: .lunch, order: index + 1)
+                            } + zip(Array(dinners).indices, dinners).map { index, element in
+                                .create(context: context, recipe: element, type: .dinner, order: index + 1)
+                            },
+                            note: note
+                        )
                     }
+                    dismiss()
+                } label: {
+                    Text(diary != nil ? "Update" : "Add")
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        if let diary {
-                            diary.update(
-                                date: date,
-                                objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
-                                    .create(context: context, recipe: element, type: .breakfast, order: index + 1)
-                                } + zip(Array(lunches).indices, lunches).map { index, element in
-                                    .create(context: context, recipe: element, type: .lunch, order: index + 1)
-                                } + zip(Array(dinners).indices, dinners).map { index, element in
-                                    .create(context: context, recipe: element, type: .dinner, order: index + 1)
-                                },
-                                note: note
-                            )
-                        } else {
-                            _ = Diary.create(
-                                context: context,
-                                date: date,
-                                objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
-                                    .create(context: context, recipe: element, type: .breakfast, order: index + 1)
-                                } + zip(Array(lunches).indices, lunches).map { index, element in
-                                    .create(context: context, recipe: element, type: .lunch, order: index + 1)
-                                } + zip(Array(dinners).indices, dinners).map { index, element in
-                                    .create(context: context, recipe: element, type: .dinner, order: index + 1)
-                                },
-                                note: note
-                            )
-                        }
-                        dismiss()
-                    } label: {
-                        Text(diary != nil ? "Update" : "Add")
-                    }
-                    .disabled(breakfasts.isEmpty && lunches.isEmpty && dinners.isEmpty)
-                }
+                .disabled(breakfasts.isEmpty && lunches.isEmpty && dinners.isEmpty)
             }
         }
         .interactiveDismissDisabled()

--- a/Cookle/Sources/Diary/View/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/View/DiaryFormView.swift
@@ -1,0 +1,128 @@
+//
+//  DiaryFormView.swift
+//  Cookle
+//
+//  Created by Hiromu Nakano on 2024/04/17.
+//
+
+import SwiftData
+import SwiftUI
+
+struct DiaryFormView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    @Environment(Diary.self) private var diary: Diary?
+
+    @State private var date = Date.now
+    @State private var breakfasts = Set<Recipe>()
+    @State private var lunches = Set<Recipe>()
+    @State private var dinners = Set<Recipe>()
+    @State private var note = ""
+
+    var body: some View {
+        Form {
+            Section {
+                DatePicker("Date", selection: $date, displayedComponents: .date)
+                    .datePickerStyle(.graphical)
+            }
+            Section {
+                NavigationLink(value: DiaryObjectType.breakfast) {
+                    Text(DiaryObjectType.breakfast.title)
+                }
+            } footer: {
+                Text(breakfasts.map(\.name).joined(separator: ", "))
+            }
+            Section {
+                NavigationLink(value: DiaryObjectType.lunch) {
+                    Text(DiaryObjectType.lunch.title)
+                }
+            } footer: {
+                Text(lunches.map(\.name).joined(separator: ", "))
+            }
+            Section {
+                NavigationLink(value: DiaryObjectType.dinner) {
+                    Text(DiaryObjectType.dinner.title)
+                }
+            } footer: {
+                Text(dinners.map(\.name).joined(separator: ", "))
+            }
+            Section {
+                TextField(text: $note, axis: .vertical) {
+                    Text("Classic spaghetti carbonara and warm beef stew for a comforting end to the day.")
+                }
+            } header: {
+                Text("Note")
+            }
+            }
+            .navigationDestination(for: DiaryObjectType.self) { type in
+                switch type {
+                case .breakfast:
+                    DiaryFormRecipeListView(selection: $breakfasts, type: type)
+                case .lunch:
+                    DiaryFormRecipeListView(selection: $lunches, type: type)
+                case .dinner:
+                    DiaryFormRecipeListView(selection: $dinners, type: type)
+                }
+            }
+            .navigationTitle(Text("Diary"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("Cancel")
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        if let diary {
+                            diary.update(
+                                date: date,
+                                objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
+                                    .create(context: context, recipe: element, type: .breakfast, order: index + 1)
+                                } + zip(Array(lunches).indices, lunches).map { index, element in
+                                    .create(context: context, recipe: element, type: .lunch, order: index + 1)
+                                } + zip(Array(dinners).indices, dinners).map { index, element in
+                                    .create(context: context, recipe: element, type: .dinner, order: index + 1)
+                                },
+                                note: note
+                            )
+                        } else {
+                            _ = Diary.create(
+                                context: context,
+                                date: date,
+                                objects: zip(Array(breakfasts).indices, breakfasts).map { index, element in
+                                    .create(context: context, recipe: element, type: .breakfast, order: index + 1)
+                                } + zip(Array(lunches).indices, lunches).map { index, element in
+                                    .create(context: context, recipe: element, type: .lunch, order: index + 1)
+                                } + zip(Array(dinners).indices, dinners).map { index, element in
+                                    .create(context: context, recipe: element, type: .dinner, order: index + 1)
+                                },
+                                note: note
+                            )
+                        }
+                        dismiss()
+                    } label: {
+                        Text(diary != nil ? "Update" : "Add")
+                    }
+                    .disabled(breakfasts.isEmpty && lunches.isEmpty && dinners.isEmpty)
+                }
+            }
+        }
+        .interactiveDismissDisabled()
+        .task {
+            date = diary?.date ?? .now
+            breakfasts = .init(diary?.objects.orEmpty.filter { $0.type == .breakfast }.sorted().compactMap(\.recipe) ?? [])
+            lunches = .init(diary?.objects.orEmpty.filter { $0.type == .lunch }.sorted().compactMap(\.recipe) ?? [])
+            dinners = .init(diary?.objects.orEmpty.filter { $0.type == .dinner }.sorted().compactMap(\.recipe) ?? [])
+            note = diary?.note ?? ""
+        }
+    }
+}
+
+#Preview {
+    CooklePreview { _ in
+        DiaryFormNavigationView()
+    }
+}

--- a/Cookle/Sources/Photo/View/PhotoDetailNavigationView.swift
+++ b/Cookle/Sources/Photo/View/PhotoDetailNavigationView.swift
@@ -1,46 +1,18 @@
 import SwiftUI
-import SwiftUtilities
 
 struct PhotoDetailNavigationView: View {
-    @State private var currentID: Photo.ID?
-
     private let photos: [Photo]
+    private let initialValue: Photo?
 
     init(photos: [Photo], initialValue: Photo? = nil) {
         self.photos = photos
-        self._currentID = .init(initialValue: initialValue?.id)
+        self.initialValue = initialValue
     }
 
     var body: some View {
         NavigationStack {
-            GeometryReader { geometry in
-                ScrollView(.horizontal) {
-                    LazyHStack(spacing: .zero) {
-                        ForEach(photos) { photo in
-                            if let image = UIImage(data: photo.data) {
-                                Image(uiImage: image)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(
-                                        width: geometry.size.width,
-                                        height: geometry.size.height
-                                    )
-                            }
-                        }
-                    }
-                    .scrollTargetLayout()
-                }
-                .scrollTargetBehavior(.paging)
-                .scrollPosition(id: $currentID)
-            }
-            .ignoresSafeArea(edges: .top)
-            .toolbar {
-                ToolbarItem {
-                    CloseButton()
-                }
-            }
+            PhotoDetailView(photos: photos, initialValue: initialValue)
         }
-        .environment(\.colorScheme, .dark)
     }
 }
 

--- a/Cookle/Sources/Photo/View/PhotoDetailView.swift
+++ b/Cookle/Sources/Photo/View/PhotoDetailView.swift
@@ -16,27 +16,26 @@ struct PhotoDetailView: View {
             ScrollView(.horizontal) {
                 LazyHStack(spacing: .zero) {
                     ForEach(photos) { photo in
-                            if let image = UIImage(data: photo.data) {
-                                Image(uiImage: image)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(
-                                        width: geometry.size.width,
-                                        height: geometry.size.height
-                                    )
-                            }
+                        if let image = UIImage(data: photo.data) {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(
+                                    width: geometry.size.width,
+                                    height: geometry.size.height
+                                )
                         }
                     }
-                    .scrollTargetLayout()
                 }
-                .scrollTargetBehavior(.paging)
-                .scrollPosition(id: $currentID)
+                .scrollTargetLayout()
             }
-            .ignoresSafeArea(edges: .top)
-            .toolbar {
-                ToolbarItem {
-                    CloseButton()
-                }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: $currentID)
+        }
+        .ignoresSafeArea(edges: .top)
+        .toolbar {
+            ToolbarItem {
+                CloseButton()
             }
         }
         .environment(\.colorScheme, .dark)

--- a/Cookle/Sources/Photo/View/PhotoDetailView.swift
+++ b/Cookle/Sources/Photo/View/PhotoDetailView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import SwiftUtilities
+
+struct PhotoDetailView: View {
+    @State private var currentID: Photo.ID?
+
+    private let photos: [Photo]
+
+    init(photos: [Photo], initialValue: Photo? = nil) {
+        self.photos = photos
+        self._currentID = .init(initialValue: initialValue?.id)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView(.horizontal) {
+                LazyHStack(spacing: .zero) {
+                    ForEach(photos) { photo in
+                            if let image = UIImage(data: photo.data) {
+                                Image(uiImage: image)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(
+                                        width: geometry.size.width,
+                                        height: geometry.size.height
+                                    )
+                            }
+                        }
+                    }
+                    .scrollTargetLayout()
+                }
+                .scrollTargetBehavior(.paging)
+                .scrollPosition(id: $currentID)
+            }
+            .ignoresSafeArea(edges: .top)
+            .toolbar {
+                ToolbarItem {
+                    CloseButton()
+                }
+            }
+        }
+        .environment(\.colorScheme, .dark)
+    }
+}
+
+#Preview {
+    CooklePreview { preview in
+        PhotoDetailNavigationView(photos: preview.photos)
+    }
+}

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipePhotosSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipePhotosSection.swift
@@ -40,7 +40,10 @@ struct RecipePhotosSection: View {
                 .listRowBackground(EmptyView())
             }
             .fullScreenCover(item: $selectedPhoto) { photo in
-                PhotoDetailNavigationView(photos: objects.sorted().compactMap(\.photo), initialValue: photo)
+                PhotoDetailNavigationView(
+                    photos: objects.sorted().compactMap(\.photo),
+                    initialValue: photo
+                )
             }
         }
     }

--- a/Cookle/Sources/Recipe/View/AddMultipleTextsNavigationView.swift
+++ b/Cookle/Sources/Recipe/View/AddMultipleTextsNavigationView.swift
@@ -1,64 +1,20 @@
 import SwiftUI
 
 struct AddMultipleTextsNavigationView: View {
-    @Environment(\.dismiss) private var dismiss
-
-    @Binding private var texts: [String]
-
-    @State private var text: String
-
+    @Binding var texts: [String]
     private let title: LocalizedStringKey
     private let placeholder: LocalizedStringKey
 
     init(texts: Binding<[String]>, title: LocalizedStringKey, placeholder: LocalizedStringKey) {
         self._texts = texts
-        self.text = texts.wrappedValue.joined(separator: "\n")
         self.title = title
         self.placeholder = placeholder
     }
 
     var body: some View {
         NavigationStack {
-            TextEditor(text: $text)
-                .overlay(alignment: .topLeading) {
-                    Text(placeholder)
-                        .font(.body)
-                        .foregroundStyle(.placeholder)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 6)
-                        .allowsHitTesting(false)
-                        .hidden(text.isNotEmpty)
-                }
-                .padding()
-                .scrollContentBackground(.hidden)
-                .background(Color(.secondarySystemGroupedBackground))
-                .clipShape(.rect(cornerRadius: 8))
-                .padding()
-                .background(Color(.systemGroupedBackground))
-                .navigationTitle(title)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button {
-                            text = ""
-                            dismiss()
-                        } label: {
-                            Text("Cancel")
-                        }
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button {
-                            texts = text.split(separator: "\n", omittingEmptySubsequences: false).map {
-                                String($0)
-                            }
-                            text = ""
-                            dismiss()
-                        } label: {
-                            Text("Done")
-                        }
-                    }
-                }
+            AddMultipleTextsView(texts: $texts, title: title, placeholder: placeholder)
         }
-        .font(nil)
     }
 }
 

--- a/Cookle/Sources/Recipe/View/AddMultipleTextsView.swift
+++ b/Cookle/Sources/Recipe/View/AddMultipleTextsView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct AddMultipleTextsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding private var texts: [String]
+
+    @State private var text: String
+
+    private let title: LocalizedStringKey
+    private let placeholder: LocalizedStringKey
+
+    init(texts: Binding<[String]>, title: LocalizedStringKey, placeholder: LocalizedStringKey) {
+        self._texts = texts
+        self.text = texts.wrappedValue.joined(separator: "\n")
+        self.title = title
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        TextEditor(text: $text)
+            .overlay(alignment: .topLeading) {
+                Text(placeholder)
+                    .font(.body)
+                    .foregroundStyle(.placeholder)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 6)
+                    .allowsHitTesting(false)
+                    .hidden(text.isNotEmpty)
+            }
+            .padding()
+            .scrollContentBackground(.hidden)
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(.rect(cornerRadius: 8))
+            .padding()
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        text = ""
+                        dismiss()
+                    } label: {
+                        Text("Cancel")
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        texts = text.split(separator: "\n", omittingEmptySubsequences: false).map {
+                            String($0)
+                        }
+                        text = ""
+                        dismiss()
+                    } label: {
+                        Text("Done")
+                    }
+                }
+            }
+            .font(nil)
+    }
+}
+
+#Preview {
+    AddMultipleTextsNavigationView(
+        texts: .constant([]),
+        title: "Ingredients",
+        placeholder: """
+                     Boil water in a large pot and add salt.
+                     Cook the spaghetti until al dente.
+                     In a separate pan, cook the pancetta until crispy.
+                     Beat the eggs in a bowl and mix with grated Parmesan cheese.
+                     Drain the spaghetti and mix with pancetta and the egg mixture.
+                     Season with black pepper and serve immediately.
+                     """
+    )
+}

--- a/Cookle/Sources/Recipe/View/RecipeFormNavigationView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeFormNavigationView.swift
@@ -1,32 +1,6 @@
-//
-//  RecipeFormNavigationView.swift
-//  Cookle
-//
-//  Created by Hiromu Nakano on 2024/04/11.
-//
-
-import StoreKit
 import SwiftUI
 
 struct RecipeFormNavigationView: View {
-    @Environment(\.dismiss) private var dismiss
-
-    @Environment(Recipe.self) private var recipe: Recipe?
-
-    @AppStorage(.isDebugOn) private var isDebugOn
-
-    @State private var name = ""
-    @State private var photos = [PhotoData]()
-    @State private var servingSize = ""
-    @State private var cookingTime = ""
-    @State private var ingredients = [RecipeFormIngredient]()
-    @State private var steps = [String]()
-    @State private var categories = [String]()
-    @State private var note = ""
-
-    @State private var editMode = EditMode.inactive
-    @State private var isDebugAlertPresented = false
-
     private let type: RecipeFormType
 
     init(type: RecipeFormType) {
@@ -35,141 +9,11 @@ struct RecipeFormNavigationView: View {
 
     var body: some View {
         NavigationStack {
-            Form {
-                RecipeFormNameSection($name)
-                    .hidden(editMode == .active)
-                RecipeFormPhotosSection($photos)
-                RecipeFormServingSizeSection($servingSize)
-                    .hidden(editMode == .active)
-                RecipeFormCookingTimeSection($cookingTime)
-                    .hidden(editMode == .active)
-                RecipeFormIngredientsSection($ingredients)
-                RecipeFormStepsSection($steps)
-                RecipeFormCategoriesSection($categories)
-                RecipeFormNoteSection($note)
-                    .hidden(editMode == .active)
-                Section {
-                    Button {
-                        withAnimation {
-                            editMode = editMode.isEditing ? .inactive : .active
-                        }
-                    } label: {
-                        editMode == .inactive ? Text("Change Order or Delete Row") : Text("Done Edit")
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-            }
-            .environment(\.editMode, $editMode)
-            .navigationTitle(editMode == .inactive ? Text("Recipe") : Text("Editing..."))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        if name == "Enable Debug" {
-                            name = .empty
-                            isDebugAlertPresented = true
-                            return
-                        }
-                        dismiss()
-                    } label: {
-                        Text("Cancel")
-                    }
-                }
-                switch editMode {
-                case .active:
-                    ToolbarItem {
-                        Button {
-                            withAnimation {
-                                editMode = .inactive
-                            }
-                        } label: {
-                            Text("Done")
-                        }
-                    }
-                default:
-                    switch type {
-                    case .create,
-                         .duplicate:
-                        ToolbarItem(placement: .confirmationAction) {
-                            CreateRecipeButton(
-                                name: name,
-                                photos: photos,
-                                servingSize: servingSize,
-                                cookingTime: cookingTime,
-                                ingredients: ingredients,
-                                steps: steps,
-                                categories: categories,
-                                note: note,
-                                useShortTitle: true
-                            )
-                            .labelStyle(.titleOnly)
-                        }
-                    case .edit:
-                        ToolbarItem(placement: .confirmationAction) {
-                            UpdateRecipeButton(
-                                name: name,
-                                photos: photos,
-                                servingSize: servingSize,
-                                cookingTime: cookingTime,
-                                ingredients: ingredients,
-                                steps: steps,
-                                categories: categories,
-                                note: note,
-                                useShortTitle: true
-                            )
-                            .labelStyle(.titleOnly)
-                        }
-                    }
-                }
-            }
-        }
-        .interactiveDismissDisabled()
-        .confirmationDialog(
-            Text("Debug"),
-            isPresented: $isDebugAlertPresented
-        ) {
-            Button {
-                isDebugOn = true
-                dismiss()
-            } label: {
-                Text("OK")
-            }
-            Button(role: .cancel) {
-            } label: {
-                Text("Cancel")
-            }
-        } message: {
-            Text("Are you really going to use DebugMode?")
-        }
-        .task {
-            name = recipe?.name ?? .empty
-            photos = recipe?.photoObjects?.sorted().compactMap {
-                guard let photo = $0.photo else {
-                    return nil
-                }
-                return .init(data: photo.data, source: photo.source)
-            } ?? .empty
-            servingSize = recipe?.servingSize.description ?? .empty
-            cookingTime = recipe?.cookingTime.description ?? .empty
-            ingredients = (recipe?.ingredientObjects?.sorted().compactMap { object in
-                guard let ingredient = object.ingredient else {
-                    return nil
-                }
-                return (ingredient.value, object.amount)
-            } ?? .empty) + [(.empty, .empty)]
-            steps = (recipe?.steps ?? .empty) + [.empty]
-            categories = (recipe?.categories?.map(\.value) ?? .empty) + [.empty]
-            note = recipe?.note ?? .empty
+            RecipeFormView(type: type)
         }
     }
 }
 
 #Preview {
     RecipeFormNavigationView(type: .create)
-}
-
-#Preview {
-    CooklePreview { preview in
-        RecipeFormNavigationView(type: .edit)
-            .environment(preview.recipes[0])
-    }
 }

--- a/Cookle/Sources/Recipe/View/RecipeFormView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeFormView.swift
@@ -1,0 +1,174 @@
+//
+//  RecipeFormView.swift
+//  Cookle
+//
+//  Created by Hiromu Nakano on 2024/04/11.
+//
+
+import StoreKit
+import SwiftUI
+
+struct RecipeFormView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Environment(Recipe.self) private var recipe: Recipe?
+
+    @AppStorage(.isDebugOn) private var isDebugOn
+
+    @State private var name = ""
+    @State private var photos = [PhotoData]()
+    @State private var servingSize = ""
+    @State private var cookingTime = ""
+    @State private var ingredients = [RecipeFormIngredient]()
+    @State private var steps = [String]()
+    @State private var categories = [String]()
+    @State private var note = ""
+
+    @State private var editMode = EditMode.inactive
+    @State private var isDebugAlertPresented = false
+
+    private let type: RecipeFormType
+
+    init(type: RecipeFormType) {
+        self.type = type
+    }
+
+    var body: some View {
+        Form {
+            RecipeFormNameSection($name)
+                .hidden(editMode == .active)
+                RecipeFormPhotosSection($photos)
+                RecipeFormServingSizeSection($servingSize)
+                    .hidden(editMode == .active)
+                RecipeFormCookingTimeSection($cookingTime)
+                    .hidden(editMode == .active)
+                RecipeFormIngredientsSection($ingredients)
+                RecipeFormStepsSection($steps)
+                RecipeFormCategoriesSection($categories)
+                RecipeFormNoteSection($note)
+                    .hidden(editMode == .active)
+                Section {
+                    Button {
+                        withAnimation {
+                            editMode = editMode.isEditing ? .inactive : .active
+                        }
+                    } label: {
+                        editMode == .inactive ? Text("Change Order or Delete Row") : Text("Done Edit")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .environment(\.editMode, $editMode)
+            .navigationTitle(editMode == .inactive ? Text("Recipe") : Text("Editing..."))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        if name == "Enable Debug" {
+                            name = .empty
+                            isDebugAlertPresented = true
+                            return
+                        }
+                        dismiss()
+                    } label: {
+                        Text("Cancel")
+                    }
+                }
+                switch editMode {
+                case .active:
+                    ToolbarItem {
+                        Button {
+                            withAnimation {
+                                editMode = .inactive
+                            }
+                        } label: {
+                            Text("Done")
+                        }
+                    }
+                default:
+                    switch type {
+                    case .create,
+                         .duplicate:
+                        ToolbarItem(placement: .confirmationAction) {
+                            CreateRecipeButton(
+                                name: name,
+                                photos: photos,
+                                servingSize: servingSize,
+                                cookingTime: cookingTime,
+                                ingredients: ingredients,
+                                steps: steps,
+                                categories: categories,
+                                note: note,
+                                useShortTitle: true
+                            )
+                            .labelStyle(.titleOnly)
+                        }
+                    case .edit:
+                        ToolbarItem(placement: .confirmationAction) {
+                            UpdateRecipeButton(
+                                name: name,
+                                photos: photos,
+                                servingSize: servingSize,
+                                cookingTime: cookingTime,
+                                ingredients: ingredients,
+                                steps: steps,
+                                categories: categories,
+                                note: note,
+                                useShortTitle: true
+                            )
+                            .labelStyle(.titleOnly)
+                        }
+                    }
+                }
+            }
+        }
+        .interactiveDismissDisabled()
+        .confirmationDialog(
+            Text("Debug"),
+            isPresented: $isDebugAlertPresented
+        ) {
+            Button {
+                isDebugOn = true
+                dismiss()
+            } label: {
+                Text("OK")
+            }
+            Button(role: .cancel) {
+            } label: {
+                Text("Cancel")
+            }
+        } message: {
+            Text("Are you really going to use DebugMode?")
+        }
+        .task {
+            name = recipe?.name ?? .empty
+            photos = recipe?.photoObjects?.sorted().compactMap {
+                guard let photo = $0.photo else {
+                    return nil
+                }
+                return .init(data: photo.data, source: photo.source)
+            } ?? .empty
+            servingSize = recipe?.servingSize.description ?? .empty
+            cookingTime = recipe?.cookingTime.description ?? .empty
+            ingredients = (recipe?.ingredientObjects?.sorted().compactMap { object in
+                guard let ingredient = object.ingredient else {
+                    return nil
+                }
+                return (ingredient.value, object.amount)
+            } ?? .empty) + [(.empty, .empty)]
+            steps = (recipe?.steps ?? .empty) + [.empty]
+            categories = (recipe?.categories?.map(\.value) ?? .empty) + [.empty]
+            note = recipe?.note ?? .empty
+        }
+    }
+}
+
+#Preview {
+    RecipeFormNavigationView(type: .create)
+}
+
+#Preview {
+    CooklePreview { preview in
+        RecipeFormNavigationView(type: .edit)
+            .environment(preview.recipes[0])
+    }
+}

--- a/Cookle/Sources/Recipe/View/RecipeFormView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeFormView.swift
@@ -37,86 +37,85 @@ struct RecipeFormView: View {
         Form {
             RecipeFormNameSection($name)
                 .hidden(editMode == .active)
-                RecipeFormPhotosSection($photos)
-                RecipeFormServingSizeSection($servingSize)
-                    .hidden(editMode == .active)
-                RecipeFormCookingTimeSection($cookingTime)
-                    .hidden(editMode == .active)
-                RecipeFormIngredientsSection($ingredients)
-                RecipeFormStepsSection($steps)
-                RecipeFormCategoriesSection($categories)
-                RecipeFormNoteSection($note)
-                    .hidden(editMode == .active)
-                Section {
-                    Button {
-                        withAnimation {
-                            editMode = editMode.isEditing ? .inactive : .active
-                        }
-                    } label: {
-                        editMode == .inactive ? Text("Change Order or Delete Row") : Text("Done Edit")
+            RecipeFormPhotosSection($photos)
+            RecipeFormServingSizeSection($servingSize)
+                .hidden(editMode == .active)
+            RecipeFormCookingTimeSection($cookingTime)
+                .hidden(editMode == .active)
+            RecipeFormIngredientsSection($ingredients)
+            RecipeFormStepsSection($steps)
+            RecipeFormCategoriesSection($categories)
+            RecipeFormNoteSection($note)
+                .hidden(editMode == .active)
+            Section {
+                Button {
+                    withAnimation {
+                        editMode = editMode.isEditing ? .inactive : .active
                     }
-                    .frame(maxWidth: .infinity)
+                } label: {
+                    editMode == .inactive ? Text("Change Order or Delete Row") : Text("Done Edit")
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .environment(\.editMode, $editMode)
+        .navigationTitle(editMode == .inactive ? Text("Recipe") : Text("Editing..."))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button {
+                    if name == "Enable Debug" {
+                        name = .empty
+                        isDebugAlertPresented = true
+                        return
+                    }
+                    dismiss()
+                } label: {
+                    Text("Cancel")
                 }
             }
-            .environment(\.editMode, $editMode)
-            .navigationTitle(editMode == .inactive ? Text("Recipe") : Text("Editing..."))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
+            switch editMode {
+            case .active:
+                ToolbarItem {
                     Button {
-                        if name == "Enable Debug" {
-                            name = .empty
-                            isDebugAlertPresented = true
-                            return
+                        withAnimation {
+                            editMode = .inactive
                         }
-                        dismiss()
                     } label: {
-                        Text("Cancel")
+                        Text("Done")
                     }
                 }
-                switch editMode {
-                case .active:
-                    ToolbarItem {
-                        Button {
-                            withAnimation {
-                                editMode = .inactive
-                            }
-                        } label: {
-                            Text("Done")
-                        }
+            default:
+                switch type {
+                case .create,
+                     .duplicate:
+                    ToolbarItem(placement: .confirmationAction) {
+                        CreateRecipeButton(
+                            name: name,
+                            photos: photos,
+                            servingSize: servingSize,
+                            cookingTime: cookingTime,
+                            ingredients: ingredients,
+                            steps: steps,
+                            categories: categories,
+                            note: note,
+                            useShortTitle: true
+                        )
+                        .labelStyle(.titleOnly)
                     }
-                default:
-                    switch type {
-                    case .create,
-                         .duplicate:
-                        ToolbarItem(placement: .confirmationAction) {
-                            CreateRecipeButton(
-                                name: name,
-                                photos: photos,
-                                servingSize: servingSize,
-                                cookingTime: cookingTime,
-                                ingredients: ingredients,
-                                steps: steps,
-                                categories: categories,
-                                note: note,
-                                useShortTitle: true
-                            )
-                            .labelStyle(.titleOnly)
-                        }
-                    case .edit:
-                        ToolbarItem(placement: .confirmationAction) {
-                            UpdateRecipeButton(
-                                name: name,
-                                photos: photos,
-                                servingSize: servingSize,
-                                cookingTime: cookingTime,
-                                ingredients: ingredients,
-                                steps: steps,
-                                categories: categories,
-                                note: note,
-                                useShortTitle: true
-                            )
-                            .labelStyle(.titleOnly)
-                        }
+                case .edit:
+                    ToolbarItem(placement: .confirmationAction) {
+                        UpdateRecipeButton(
+                            name: name,
+                            photos: photos,
+                            servingSize: servingSize,
+                            cookingTime: cookingTime,
+                            ingredients: ingredients,
+                            steps: steps,
+                            categories: categories,
+                            note: note,
+                            useShortTitle: true
+                        )
+                        .labelStyle(.titleOnly)
                     }
                 }
             }

--- a/Cookle/Sources/Tag/View/TagFormNavigationView.swift
+++ b/Cookle/Sources/Tag/View/TagFormNavigationView.swift
@@ -1,61 +1,13 @@
-import SwiftData
 import SwiftUI
 
 struct TagFormNavigationView<T: Tag>: View {
-    @Environment(\.dismiss) private var dismiss
-
-    @Environment(T.self) private var tag: T
-
-    @State private var value = ""
-
     var body: some View {
         NavigationStack {
-            Form {
-                Section {
-                    TextField(text: $value) {
-                        Text("Spaghetti")
-                    }
-                } header: {
-                    Text("Value")
-                }
-                Section {
-                    ForEach(tag.recipes.orEmpty) {
-                        Text($0.name)
-                    }
-                } header: {
-                    Text("Recipes")
-                }
-            }
-            .navigationTitle("Edit " + tag.value)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("Cancel")
-                    }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        tag.update(value: value)
-                        dismiss()
-                    } label: {
-                        Text("Update")
-                    }
-                    .disabled(value.isEmpty)
-                }
-            }
-        }
-        .interactiveDismissDisabled()
-        .task {
-            value = tag.value
+            TagFormView<T>()
         }
     }
 }
 
 #Preview {
-    CooklePreview { preview in
-        TagFormNavigationView<Category>()
-            .environment(preview.categories[0])
-    }
+    TagFormNavigationView<Category>()
 }

--- a/Cookle/Sources/Tag/View/TagFormView.swift
+++ b/Cookle/Sources/Tag/View/TagFormView.swift
@@ -1,0 +1,59 @@
+import SwiftData
+import SwiftUI
+
+struct TagFormView<T: Tag>: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Environment(T.self) private var tag: T
+
+    @State private var value = ""
+
+    var body: some View {
+        Form {
+            Section {
+                TextField(text: $value) {
+                    Text("Spaghetti")
+                }
+            } header: {
+                Text("Value")
+            }
+            Section {
+                ForEach(tag.recipes.orEmpty) {
+                    Text($0.name)
+                }
+            } header: {
+                Text("Recipes")
+            }
+        }
+        .navigationTitle("Edit " + tag.value)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Cancel")
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button {
+                    tag.update(value: value)
+                    dismiss()
+                } label: {
+                    Text("Update")
+                }
+                .disabled(value.isEmpty)
+            }
+        }
+        .interactiveDismissDisabled()
+        .task {
+            value = tag.value
+        }
+    }
+}
+
+#Preview {
+    CooklePreview { preview in
+        TagFormNavigationView<Category>()
+            .environment(preview.categories[0])
+    }
+}


### PR DESCRIPTION
## Summary
- move logic out of `NavigationStack`-embedded forms
- create lightweight `*NavigationView` wrappers
- use the wrappers when presenting forms

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450857f220832085562464b4342595