### PR TITLE
Add FoundationModels recipe summarization

### DIFF
--- a/Cookle/Resources/Localizable.xcstrings
+++ b/Cookle/Resources/Localizable.xcstrings
@@ -1447,6 +1447,9 @@
         }
       }
     },
+    "Generate From Photo" : {
+
+    },
     "iCloud On" : {
       "localizations" : {
         "en" : {

--- a/Cookle/Sources/Common/Model/CookleFoundationModel.swift
+++ b/Cookle/Sources/Common/Model/CookleFoundationModel.swift
@@ -1,0 +1,75 @@
+//
+//  CookleFoundationModel.swift
+//  Cookle Playgrounds
+//
+//  Created by codex on 2025/06/30.
+//
+
+import SwiftUI
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+enum CookleFoundationModel {
+    static var isSupported: Bool {
+        if #available(iOS 19.0, *) {
+#if canImport(FoundationModels)
+            switch SystemLanguageModel.default.availability {
+            case .available:
+                return true
+            case .unavailable:
+                return false
+            }
+#else
+            return false
+#endif
+        } else {
+            return false
+        }
+    }
+
+
+    @available(iOS 19.0, *)
+    static func summarizeRecipe(_ text: String) async throws -> RecipeDraft {
+#if canImport(FoundationModels)
+        @Generable
+        struct Ingredient {
+            var ingredient: String
+            var amount: String
+        }
+
+        @Generable
+        struct Draft {
+            var name: String
+            var servingSize: String
+            var cookingTime: String
+            var ingredients: [Ingredient]
+            var steps: [String]
+            var note: String
+        }
+
+        let prompt = """
+        Summarize the following OCR text into a recipe with the properties name, servingSize, cookingTime, ingredients, steps and note.
+
+        \(text)
+        """
+
+        let session = LanguageModelSession()
+        let response = try await session.respond(
+            to: prompt,
+            generating: Draft.self
+        )
+
+        var draft = RecipeDraft()
+        draft.name = response.content.name
+        draft.servingSize = response.content.servingSize
+        draft.cookingTime = response.content.cookingTime
+        draft.ingredients = response.content.ingredients.map { ($0.ingredient, $0.amount) }
+        draft.steps = response.content.steps
+        draft.note = response.content.note
+        return draft
+#else
+        throw OCRRecipeBuilder.OCRRecipeBuilderError.unsupported
+#endif
+    }
+}

--- a/Cookle/Sources/Common/Model/CookleFoundationModel.swift
+++ b/Cookle/Sources/Common/Model/CookleFoundationModel.swift
@@ -5,49 +5,37 @@
 //  Created by codex on 2025/06/30.
 //
 
-import SwiftUI
-#if canImport(FoundationModels)
 import FoundationModels
-#endif
+import SwiftUI
 
+@available(iOS 26.0, *)
 enum CookleFoundationModel {
+    @Generable
+    struct Ingredient {
+        var ingredient: String
+        var amount: String
+    }
+
+    @Generable
+    struct Draft {
+        var name: String
+        var servingSize: String
+        var cookingTime: String
+        var ingredients: [Ingredient]
+        var steps: [String]
+        var note: String
+    }
+
     static var isSupported: Bool {
-        if #available(iOS 19.0, *) {
-#if canImport(FoundationModels)
-            switch SystemLanguageModel.default.availability {
-            case .available:
-                return true
-            case .unavailable:
-                return false
-            }
-#else
-            return false
-#endif
-        } else {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return true
+        case .unavailable:
             return false
         }
     }
 
-
-    @available(iOS 19.0, *)
     static func summarizeRecipe(_ text: String) async throws -> RecipeDraft {
-#if canImport(FoundationModels)
-        @Generable
-        struct Ingredient {
-            var ingredient: String
-            var amount: String
-        }
-
-        @Generable
-        struct Draft {
-            var name: String
-            var servingSize: String
-            var cookingTime: String
-            var ingredients: [Ingredient]
-            var steps: [String]
-            var note: String
-        }
-
         let prompt = """
         Summarize the following OCR text into a recipe with the properties name, servingSize, cookingTime, ingredients, steps and note.
 
@@ -68,8 +56,5 @@ enum CookleFoundationModel {
         draft.steps = response.content.steps
         draft.note = response.content.note
         return draft
-#else
-        throw OCRRecipeBuilder.OCRRecipeBuilderError.unsupported
-#endif
     }
 }

--- a/Cookle/Sources/Common/Model/OCRRecipeBuilder.swift
+++ b/Cookle/Sources/Common/Model/OCRRecipeBuilder.swift
@@ -1,0 +1,42 @@
+//
+//  OCRRecipeBuilder.swift
+//  Cookle
+//
+//  Created by codex on 2025/06/30.
+//
+
+import SwiftUI
+import Vision
+
+struct RecipeDraft {
+    var name = String.empty
+    var servingSize = String.empty
+    var cookingTime = String.empty
+    var ingredients = [RecipeFormIngredient]()
+    var steps = [String]()
+    var note = String.empty
+}
+
+enum OCRRecipeBuilder {
+    enum OCRRecipeBuilderError: Error {
+        case invalidImage
+        case unsupported
+    }
+
+    @available(iOS 19.0, *)
+    static func build(from data: Data) async throws -> RecipeDraft {
+        guard CookleFoundationModel.isSupported else {
+            throw OCRRecipeBuilderError.unsupported
+        }
+        guard let image = UIImage(data: data)?.cgImage else {
+            throw OCRRecipeBuilderError.invalidImage
+        }
+        let request = VNRecognizeTextRequest()
+        let handler = VNImageRequestHandler(cgImage: image)
+        try handler.perform([request])
+        let text = request.results?
+            .compactMap { ($0 as? VNRecognizedTextObservation)?.topCandidates(1).first?.string }
+            .joined(separator: "\n") ?? .empty
+        return try await CookleFoundationModel.summarizeRecipe(text)
+    }
+}

--- a/Cookle/Sources/Recipe/Component/GenerateRecipeFromPhotoButton.swift
+++ b/Cookle/Sources/Recipe/Component/GenerateRecipeFromPhotoButton.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 26.0, *)
 struct GenerateRecipeFromPhotoButton: View {
     @Binding private var photos: [PhotoData]
     @Binding private var name: String
@@ -61,6 +62,7 @@ struct GenerateRecipeFromPhotoButton: View {
     }
 }
 
+@available(iOS 26.0, *)
 #Preview {
     GenerateRecipeFromPhotoButton(
         photos: .constant([]),

--- a/Cookle/Sources/Recipe/Component/GenerateRecipeFromPhotoButton.swift
+++ b/Cookle/Sources/Recipe/Component/GenerateRecipeFromPhotoButton.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct GenerateRecipeFromPhotoButton: View {
+    @Binding private var photos: [PhotoData]
+    @Binding private var name: String
+    @Binding private var servingSize: String
+    @Binding private var cookingTime: String
+    @Binding private var ingredients: [RecipeFormIngredient]
+    @Binding private var steps: [String]
+    @Binding private var note: String
+
+    @State private var isProcessing = false
+
+    init(photos: Binding<[PhotoData]>,
+         name: Binding<String>,
+         servingSize: Binding<String>,
+         cookingTime: Binding<String>,
+         ingredients: Binding<[RecipeFormIngredient]>,
+         steps: Binding<[String]>,
+         note: Binding<String>) {
+        _photos = photos
+        _name = name
+        _servingSize = servingSize
+        _cookingTime = cookingTime
+        _ingredients = ingredients
+        _steps = steps
+        _note = note
+    }
+
+    var body: some View {
+        Button {
+            guard CookleFoundationModel.isSupported,
+                  let data = photos.first?.data else { return }
+            isProcessing = true
+            Task {
+                do {
+                    let draft = try await OCRRecipeBuilder.build(from: data)
+                    name = draft.name
+                    servingSize = draft.servingSize
+                    cookingTime = draft.cookingTime
+                    ingredients = draft.ingredients + [(.empty, .empty)]
+                    steps = draft.steps + [.empty]
+                    note = draft.note
+                } catch {
+                    // ignore for now
+                }
+                isProcessing = false
+            }
+        } label: {
+            if isProcessing {
+                ProgressView()
+            } else {
+                Label {
+                    Text("Generate From Photo")
+                } icon: {
+                    Image(systemName: "text.viewfinder")
+                }
+            }
+        }
+        .disabled(isProcessing || photos.isEmpty || !CookleFoundationModel.isSupported)
+    }
+}
+
+#Preview {
+    GenerateRecipeFromPhotoButton(
+        photos: .constant([]),
+        name: .constant(""),
+        servingSize: .constant(""),
+        cookingTime: .constant(""),
+        ingredients: .constant([]),
+        steps: .constant([]),
+        note: .constant("")
+    )
+}

--- a/Cookle/Sources/Recipe/View/RecipeFormView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeFormView.swift
@@ -38,17 +38,19 @@ struct RecipeFormView: View {
             RecipeFormNameSection($name)
                 .hidden(editMode == .active)
             RecipeFormPhotosSection($photos)
-            if CookleFoundationModel.isSupported {
-                GenerateRecipeFromPhotoButton(
-                    photos: $photos,
-                    name: $name,
-                    servingSize: $servingSize,
-                    cookingTime: $cookingTime,
-                    ingredients: $ingredients,
-                    steps: $steps,
-                    note: $note
-                )
-                .hidden(editMode == .active)
+            if #available(iOS 26.0, *) {
+                if CookleFoundationModel.isSupported {
+                    GenerateRecipeFromPhotoButton(
+                        photos: $photos,
+                        name: $name,
+                        servingSize: $servingSize,
+                        cookingTime: $cookingTime,
+                        ingredients: $ingredients,
+                        steps: $steps,
+                        note: $note
+                    )
+                    .hidden(editMode == .active)
+                }
             }
             RecipeFormServingSizeSection($servingSize)
                 .hidden(editMode == .active)

--- a/Cookle/Sources/Recipe/View/RecipeFormView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeFormView.swift
@@ -38,6 +38,18 @@ struct RecipeFormView: View {
             RecipeFormNameSection($name)
                 .hidden(editMode == .active)
             RecipeFormPhotosSection($photos)
+            if CookleFoundationModel.isSupported {
+                GenerateRecipeFromPhotoButton(
+                    photos: $photos,
+                    name: $name,
+                    servingSize: $servingSize,
+                    cookingTime: $cookingTime,
+                    ingredients: $ingredients,
+                    steps: $steps,
+                    note: $note
+                )
+                .hidden(editMode == .active)
+            }
             RecipeFormServingSizeSection($servingSize)
                 .hidden(editMode == .active)
             RecipeFormCookingTimeSection($cookingTime)


### PR DESCRIPTION
## Summary
- refine `CookleFoundationModel` to use new Foundation Models
- check model availability before OCR recipe generation

## Testing
- `xcodebuild -list -project Cookle.xcodeproj` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cd106aea88320a9dd3d3b63222880