### PR TITLE
Add App Intents list screen

### DIFF
--- a/Cookle/Sources/AppIntent/View/AppIntentsListView.swift
+++ b/Cookle/Sources/AppIntent/View/AppIntentsListView.swift
@@ -1,0 +1,109 @@
+//
+//  AppIntentsListView.swift
+//  Cookle Playgrounds
+//
+//  Created by Codex on $(date +%Y/%m/%d).
+//
+
+import SwiftData
+import SwiftUI
+
+struct AppIntentsListView: View {
+    @State private var destination: Destination?
+
+    enum Destination: Hashable {
+        case search([Recipe])
+        case recipe(Recipe)
+    }
+
+    var body: some View {
+        List {
+            ForEach(Array(CookleShortcuts.appShortcuts.enumerated()), id: \._offset) { index, shortcut in
+                Button {
+                    run(shortcut)
+                } label: {
+                    Label(shortcut.shortTitle ?? "Shortcut", systemImage: shortcut.systemImageName)
+                }
+            }
+        }
+        .navigationTitle(Text("Shortcuts"))
+        .navigationDestination(for: Destination.self) { destination in
+            switch destination {
+            case let .search(recipes):
+                ScrollView {
+                    ForEach(recipes) { recipe in
+                        VStack(alignment: .leading) {
+                            Text(recipe.name)
+                                .font(.headline)
+                            if let photo = recipe.photoObjects?.min()?.photo,
+                               let image = UIImage(data: photo.data) {
+                                Image(uiImage: image)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(height: 240)
+                                    .frame(maxWidth: .infinity)
+                                    .clipShape(.rect(cornerRadius: 8))
+                            }
+                            RecipeIngredientsSection()
+                            Divider()
+                        }
+                        .environment(recipe)
+                    }
+                }
+                .safeAreaPadding()
+            case let .recipe(recipe):
+                VStack(alignment: .leading) {
+                    if let photo = recipe.photoObjects?.min()?.photo,
+                       let image = UIImage(data: photo.data) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 240)
+                            .frame(maxWidth: .infinity)
+                            .clipShape(.rect(cornerRadius: 8))
+                    }
+                    RecipeIngredientsSection()
+                    Divider()
+                    RecipeStepsSection()
+                }
+                .environment(recipe)
+                .safeAreaPadding()
+            }
+        }
+    }
+
+    private func run(_ shortcut: AppShortcut) {
+        Task { @MainActor in
+            switch shortcut.intent {
+            case is OpenCookleIntent:
+                break
+            case is ShowSearchResultIntent:
+                if let result = try? ShowSearchResultIntent.perform(searchText: "") {
+                    destination = .search(result)
+                }
+            case is ShowLastOpenedRecipeIntent:
+                if let recipe = try? ShowLastOpenedRecipeIntent.perform(id: AppStorage(.lastOpenedRecipeID).wrappedValue) {
+                    if let recipe {
+                        destination = .recipe(recipe)
+                    }
+                }
+            case is ShowRandomRecipeIntent:
+                if let recipe = try? ShowRandomRecipeIntent.perform() {
+                    if let recipe {
+                        destination = .recipe(recipe)
+                    }
+                }
+            default:
+                break
+            }
+        }
+    }
+}
+
+#Preview {
+    CooklePreview { _ in
+        NavigationStack {
+            AppIntentsListView()
+        }
+    }
+}

--- a/Cookle/Sources/AppIntent/View/AppIntentsNavigationView.swift
+++ b/Cookle/Sources/AppIntent/View/AppIntentsNavigationView.swift
@@ -1,0 +1,22 @@
+//
+//  AppIntentsNavigationView.swift
+//  Cookle Playgrounds
+//
+//  Created by Codex on $(date +%Y/%m/%d).
+//
+
+import SwiftUI
+
+struct AppIntentsNavigationView: View {
+    var body: some View {
+        NavigationStack {
+            AppIntentsListView()
+        }
+    }
+}
+
+#Preview {
+    CooklePreview { _ in
+        AppIntentsNavigationView()
+    }
+}

--- a/Cookle/Sources/Package/AppIntents/ShortcutsLinkSection.swift
+++ b/Cookle/Sources/Package/AppIntents/ShortcutsLinkSection.swift
@@ -8,6 +8,11 @@ struct ShortcutsLinkSection: View {
             appIntents()
                 .frame(maxWidth: .infinity)
                 .listRowBackground(EmptyView())
+            NavigationLink {
+                AppIntentsNavigationView()
+            } label: {
+                Text("Run Shortcuts")
+            }
         }
     }
 }

--- a/Cookle/Sources/Settings/Model/SettingsContent.swift
+++ b/Cookle/Sources/Settings/Model/SettingsContent.swift
@@ -7,4 +7,5 @@
 
 enum SettingsContent {
     case license
+    case shortcuts
 }

--- a/Cookle/Sources/Settings/View/SettingsNavigationView.swift
+++ b/Cookle/Sources/Settings/View/SettingsNavigationView.swift
@@ -10,6 +10,8 @@ struct SettingsNavigationView: View {
             switch selection {
             case .license:
                 LicenseView()
+            case .shortcuts:
+                AppIntentsNavigationView()
             case .none:
                 EmptyView()
             }

--- a/Cookle/Sources/Settings/View/SettingsSidebarView.swift
+++ b/Cookle/Sources/Settings/View/SettingsSidebarView.swift
@@ -44,6 +44,9 @@ struct SettingsSidebarView: View {
                 NavigationLink(value: SettingsContent.license) {
                     Text("Licenses")
                 }
+                NavigationLink(value: SettingsContent.shortcuts) {
+                    Text("Shortcuts")
+                }
             }
             ShortcutsLinkSection()
         }


### PR DESCRIPTION
## Summary
- add a list to run App Shortcuts in the app
- link the new shortcuts list from settings

## Testing
- `swiftc Cookle/Sources/AppIntent/View/AppIntentsListView.swift -typecheck` *(fails: no such module 'SwiftData')*


------
https://chatgpt.com/codex/tasks/task_e_684febb002bc8320bc4a1b7c9ae3d626