### PR TITLE
Add RecipeEntity for AppIntents

### DIFF
--- a/Cookle/Sources/AppIntent/Intent/ShowRandomRecipeIntent.swift
+++ b/Cookle/Sources/AppIntent/Intent/ShowRandomRecipeIntent.swift
@@ -15,16 +15,24 @@ struct ShowRandomRecipeIntent: AppIntent, IntentPerformer {
     }
 
     typealias Input = Void
-    typealias Output = Recipe?
+    typealias Output = RecipeEntity?
 
     @MainActor
-    static func perform(_: Input) throws -> Output {
+    private static func recipe() throws -> Recipe? {
         try CookleIntents.context.fetchRandom(.recipes(.all))
     }
 
     @MainActor
+    static func perform(_: Input) throws -> Output {
+        guard let recipe = try recipe() else {
+            return nil
+        }
+        return RecipeEntity(recipe)
+    }
+
+    @MainActor
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
-        guard let recipe = try Self.perform(()) else {
+        guard let recipe = try Self.recipe() else {
             return .result(dialog: "Not Found")
         }
         return .result(dialog: .init(stringLiteral: recipe.name)) {

--- a/Cookle/Sources/AppIntent/Intent/ShowSearchResultIntent.swift
+++ b/Cookle/Sources/AppIntent/Intent/ShowSearchResultIntent.swift
@@ -17,7 +17,7 @@ struct ShowSearchResultIntent: AppIntent, IntentPerformer {
     private var searchText: String
 
     typealias Input = String
-    typealias Output = [Recipe]
+    typealias Output = [RecipeEntity]
 
     @MainActor
     static func perform(_ input: Input) throws -> Output {
@@ -38,7 +38,7 @@ struct ShowSearchResultIntent: AppIntent, IntentPerformer {
         recipes += ingredients.flatMap(\.recipes.orEmpty)
         recipes += categories.flatMap(\.recipes.orEmpty)
         recipes = Array(Set(recipes))
-        return recipes
+        return recipes.compactMap(RecipeEntity.init)
     }
 
     @MainActor

--- a/Cookle/Sources/AppIntent/Model/RecipeEntity.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntity.swift
@@ -14,7 +14,7 @@ final class RecipeEntity: AppEntity {
 
     var displayRepresentation: DisplayRepresentation {
         .init(
-            title: .init(name, table: "AppIntents"),
+            title: .init(.init(name), table: "AppIntents"),
             image: .init(systemName: "book")
         )
     }

--- a/Cookle/Sources/AppIntent/Model/RecipeEntity.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntity.swift
@@ -1,0 +1,42 @@
+import AppIntents
+import SwiftUtilities
+
+@Observable
+final class RecipeEntity: AppEntity {
+    static let defaultQuery = RecipeEntityQuery()
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        .init(
+            name: .init("Recipe", table: "AppIntents"),
+            numericFormat: LocalizedStringResource("\(placeholder: .int) Recipes", table: "AppIntents")
+        )
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        .init(
+            title: .init(name, table: "AppIntents"),
+            image: .init(systemName: "book")
+        )
+    }
+
+    let id: String
+    let name: String
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+// MARK: - ModelBridgeable
+
+extension RecipeEntity: ModelBridgeable {
+    typealias Model = Recipe
+
+    convenience init?(_ model: Recipe) {
+        guard let encodedID = try? model.id.base64Encoded() else {
+            return nil
+        }
+        self.init(id: encodedID, name: model.name)
+    }
+}

--- a/Cookle/Sources/AppIntent/Model/RecipeEntity.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntity.swift
@@ -21,10 +21,40 @@ final class RecipeEntity: AppEntity {
 
     let id: String
     let name: String
+    let photos: [Data]
+    let servingSize: Int
+    let cookingTime: Int
+    let ingredients: [String]
+    let steps: [String]
+    let categories: [String]
+    let note: String
+    let createdTimestamp: Date
+    let modifiedTimestamp: Date
 
-    init(id: String, name: String) {
+    init(
+        id: String,
+        name: String,
+        photos: [Data],
+        servingSize: Int,
+        cookingTime: Int,
+        ingredients: [String],
+        steps: [String],
+        categories: [String],
+        note: String,
+        createdTimestamp: Date,
+        modifiedTimestamp: Date
+    ) {
         self.id = id
         self.name = name
+        self.photos = photos
+        self.servingSize = servingSize
+        self.cookingTime = cookingTime
+        self.ingredients = ingredients
+        self.steps = steps
+        self.categories = categories
+        self.note = note
+        self.createdTimestamp = createdTimestamp
+        self.modifiedTimestamp = modifiedTimestamp
     }
 }
 
@@ -37,6 +67,18 @@ extension RecipeEntity: ModelBridgeable {
         guard let encodedID = try? model.id.base64Encoded() else {
             return nil
         }
-        self.init(id: encodedID, name: model.name)
+        self.init(
+            id: encodedID,
+            name: model.name,
+            photos: model.photos?.compactMap(\.data) ?? .empty,
+            servingSize: model.servingSize,
+            cookingTime: model.cookingTime,
+            ingredients: model.ingredients?.map(\.value) ?? .empty,
+            steps: model.steps,
+            categories: model.categories?.map(\.value) ?? .empty,
+            note: model.note,
+            createdTimestamp: model.createdTimestamp,
+            modifiedTimestamp: model.modifiedTimestamp
+        )
     }
 }

--- a/Cookle/Sources/AppIntent/Model/RecipeEntityQuery.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntityQuery.swift
@@ -1,0 +1,26 @@
+import AppIntents
+import SwiftData
+
+struct RecipeEntityQuery: EntityStringQuery {
+    func entities(for identifiers: [RecipeEntity.ID]) throws -> [RecipeEntity] {
+        try identifiers.compactMap { id in
+            guard let pid = try? PersistentIdentifier(base64Encoded: id),
+                  let recipe = try CookleIntents.context.fetchFirst(.recipes(.idIs(pid))) else {
+                return nil
+            }
+            return RecipeEntity(recipe)
+        }
+    }
+
+    func entities(matching string: String) throws -> [RecipeEntity] {
+        try CookleIntents.context.fetch(
+            .recipes(.nameContains(string))
+        ).compactMap(RecipeEntity.init)
+    }
+
+    func suggestedEntities() throws -> [RecipeEntity] {
+        try CookleIntents.context.fetch(
+            .recipes(.all)
+        ).compactMap(RecipeEntity.init)
+    }
+}

--- a/Cookle/Sources/AppIntent/Model/RecipeEntityQuery.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntityQuery.swift
@@ -4,8 +4,8 @@ import SwiftData
 struct RecipeEntityQuery: EntityStringQuery {
     func entities(for identifiers: [RecipeEntity.ID]) throws -> [RecipeEntity] {
         try identifiers.compactMap { id in
-            guard let pid = try? PersistentIdentifier(base64Encoded: id),
-                  let recipe = try CookleIntents.context.fetchFirst(.recipes(.idIs(pid))) else {
+            let persistentIdentifier = try PersistentIdentifier(base64Encoded: id)
+            guard let recipe = try CookleIntents.context.fetchFirst(.recipes(.idIs(persistentIdentifier))) else {
                 return nil
             }
             return RecipeEntity(recipe)

--- a/Cookle/Sources/AppIntent/Model/RecipeEntityQuery.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntityQuery.swift
@@ -2,6 +2,7 @@ import AppIntents
 import SwiftData
 
 struct RecipeEntityQuery: EntityStringQuery {
+    @MainActor
     func entities(for identifiers: [RecipeEntity.ID]) throws -> [RecipeEntity] {
         try identifiers.compactMap { id in
             let persistentIdentifier = try PersistentIdentifier(base64Encoded: id)
@@ -12,12 +13,14 @@ struct RecipeEntityQuery: EntityStringQuery {
         }
     }
 
+    @MainActor
     func entities(matching string: String) throws -> [RecipeEntity] {
         try CookleIntents.context.fetch(
             .recipes(.nameContains(string))
         ).compactMap(RecipeEntity.init)
     }
 
+    @MainActor
     func suggestedEntities() throws -> [RecipeEntity] {
         try CookleIntents.context.fetch(
             .recipes(.all)


### PR DESCRIPTION
## Summary
- add `RecipeEntity` for `Recipe` data
- expose query helper `RecipeEntityQuery`
- update recipe intents to output the new entity

## Testing
- `pre-commit` *(fails: SourceKit not available)*

------
https://chatgpt.com/codex/tasks/task_e_685082422188832096ae353972b27787