### PR TITLE
Add recipe generation intent

### DIFF
--- a/Cookle/Sources/AppIntent/Intent/GenerateRecipeIntent.swift
+++ b/Cookle/Sources/AppIntent/Intent/GenerateRecipeIntent.swift
@@ -1,0 +1,58 @@
+import AppIntents
+import FoundationModels
+import SwiftUI
+import SwiftUtilities
+
+struct GenerateRecipeIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource { .init("Generate Recipe") }
+
+    @Parameter(title: "Prompt")
+    private var prompt: String
+
+    typealias Input = String
+    typealias Output = Recipe
+
+    @MainActor
+    static func perform(_ input: Input) async throws -> Output {
+        let session = LanguageModelSession()
+        let generated = try await session.respond(
+            to: "Create a cooking recipe that matches the following request:\n\(input)",
+            generating: GeneratedRecipe.self
+        ).content
+
+        let context = CookleIntents.context
+        return Recipe.create(
+            context: context,
+            name: generated.name,
+            photos: [],
+            servingSize: .zero,
+            cookingTime: .zero,
+            ingredients: generated.ingredients.enumerated().map { index, element in
+                .create(
+                    context: context,
+                    ingredient: element,
+                    amount: "",
+                    order: index + 1
+                )
+            },
+            steps: generated.steps,
+            categories: [],
+            note: ""
+        )
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
+        let recipe = try await Self.perform(prompt)
+        return .result(dialog: .init(stringLiteral: recipe.name)) {
+            CookleIntents.cookleView {
+                VStack(alignment: .leading) {
+                    RecipeIngredientsSection()
+                    Divider()
+                    RecipeStepsSection()
+                }
+                .environment(recipe)
+            }
+        }
+    }
+}

--- a/Cookle/Sources/AppIntent/Model/CookleShortcuts.swift
+++ b/Cookle/Sources/AppIntent/Model/CookleShortcuts.swift
@@ -51,5 +51,15 @@ struct CookleShortcuts: AppShortcutsProvider {
             shortTitle: "Show Random Recipe",
             systemImageName: "dice"
         )
+        AppShortcut(
+            intent: GenerateRecipeIntent(),
+            phrases: [
+                "Generate a recipe in \(.applicationName)",
+                "Create recipe with \(.applicationName)",
+                "AI recipe in \(.applicationName)"
+            ],
+            shortTitle: "Generate Recipe",
+            systemImageName: "sparkles"
+        )
     }
 }

--- a/Cookle/Sources/AppIntent/Model/GeneratedRecipe.swift
+++ b/Cookle/Sources/AppIntent/Model/GeneratedRecipe.swift
@@ -1,0 +1,13 @@
+import FoundationModels
+
+@Generable
+struct GeneratedRecipe {
+    @Guide(description: "Recipe title")
+    var name: String
+
+    @Guide(description: "List of ingredients")
+    var ingredients: [String]
+
+    @Guide(description: "Cooking steps")
+    var steps: [String]
+}

--- a/Cookle/Sources/Generator/View/RecipeGeneratorNavigationView.swift
+++ b/Cookle/Sources/Generator/View/RecipeGeneratorNavigationView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct RecipeGeneratorNavigationView: View {
+    var body: some View {
+        NavigationStack {
+            RecipeGeneratorView()
+        }
+    }
+}
+
+#Preview {
+    CooklePreview { _ in
+        RecipeGeneratorNavigationView()
+    }
+}

--- a/Cookle/Sources/Generator/View/RecipeGeneratorView.swift
+++ b/Cookle/Sources/Generator/View/RecipeGeneratorView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import AppIntents
+
+struct RecipeGeneratorView: View {
+    @State private var prompt = ""
+    @State private var recipe: Recipe?
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        List {
+            Section("Prompt") {
+                TextField("Describe your request", text: $prompt)
+                    .focused($isFocused)
+            }
+            Section {
+                Button("Generate") {
+                    Task {
+                        recipe = try? await GenerateRecipeIntent.perform(prompt)
+                        isFocused = false
+                    }
+                }
+                .disabled(prompt.isEmpty)
+            }
+            if let recipe {
+                Section("Result") {
+                    VStack(alignment: .leading) {
+                        Text(recipe.name)
+                            .font(.headline)
+                        RecipeIngredientsSection()
+                        Divider()
+                        RecipeStepsSection()
+                    }
+                    .environment(recipe)
+                }
+            }
+        }
+        .navigationTitle(Text("Generate Recipe"))
+    }
+}
+
+#Preview {
+    CooklePreview { _ in
+        NavigationStack {
+            RecipeGeneratorView()
+        }
+    }
+}

--- a/Cookle/Sources/Main/Model/MainTab.swift
+++ b/Cookle/Sources/Main/Model/MainTab.swift
@@ -11,6 +11,7 @@ enum MainTab: CaseIterable {
     case diary
     case recipe
     case photo
+    case generator
     case ingredient
     case category
     case settings
@@ -29,6 +30,8 @@ extension MainTab {
             RecipeNavigationView()
         case .photo:
             PhotoNavigationView()
+        case .generator:
+            RecipeGeneratorNavigationView()
         case .ingredient:
             TagNavigationView<Ingredient>()
         case .category:
@@ -64,6 +67,12 @@ extension MainTab {
                 Text("Photo")
             } icon: {
                 Image(systemName: "photo.stack")
+            }
+        case .generator:
+            Label {
+                Text("Generate")
+            } icon: {
+                Image(systemName: "sparkles")
             }
         case .ingredient:
             Label {

--- a/Cookle/Sources/Main/View/MainTabView.swift
+++ b/Cookle/Sources/Main/View/MainTabView.swift
@@ -17,7 +17,7 @@ struct MainTabView: View {
     private var tabs: [MainTab] {
         MainTab.allCases.filter {
             switch $0 {
-            case .diary, .recipe, .photo, .search:
+            case .diary, .recipe, .photo, .generator, .search:
                 true
             case .ingredient, .category, .settings:
                 horizontalSizeClass == .regular


### PR DESCRIPTION
## Summary
- add `GenerateRecipeIntent` using FoundationModels
- allow generating recipes from a prompt
- add UI for recipe generation
- expose the feature via a new tab and shortcut

## Testing
- `pre-commit run --files Cookle/Sources/AppIntent/Intent/GenerateRecipeIntent.swift Cookle/Sources/AppIntent/Model/GeneratedRecipe.swift Cookle/Sources/AppIntent/Model/CookleShortcuts.swift Cookle/Sources/Generator/View/RecipeGeneratorView.swift Cookle/Sources/Generator/View/RecipeGeneratorNavigationView.swift Cookle/Sources/Main/Model/MainTab.swift Cookle/Sources/Main/View/MainTabView.swift` *(fails: swiftlint crashed)*

------
https://chatgpt.com/codex/tasks/task_e_6850868f6f6c832097e153d72b9d1b2d