### PR TITLE
Add subscription screen

### DIFF
--- a/Cookle/Resources/Localizable.xcstrings
+++ b/Cookle/Resources/Localizable.xcstrings
@@ -1696,6 +1696,40 @@
         }
       }
     },
+    "Subscription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscription"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suscripción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonnement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サブスクリプション"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "订阅"
+          }
+        }
+      }
+    },
     "Lunches" : {
       "localizations" : {
         "en" : {

--- a/Cookle/Sources/Package/StoreKit/StoreListView.swift
+++ b/Cookle/Sources/Package/StoreKit/StoreListView.swift
@@ -1,11 +1,9 @@
 import SwiftUI
 
-struct SubscriptionView: View {
-    @Environment(StoreKitPackage.self) private var storeKit
-
+struct StoreListView: View {
     var body: some View {
         List {
-            storeKit()
+            StoreSection()
         }
         .navigationTitle(Text("Subscription"))
     }
@@ -14,7 +12,7 @@ struct SubscriptionView: View {
 #Preview {
     CooklePreview { _ in
         NavigationStack {
-            SubscriptionView()
+            StoreListView()
         }
     }
 }

--- a/Cookle/Sources/Package/StoreKit/SubscriptionView.swift
+++ b/Cookle/Sources/Package/StoreKit/SubscriptionView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct SubscriptionView: View {
+    @Environment(StoreKitPackage.self) private var storeKit
+
+    var body: some View {
+        List {
+            storeKit()
+        }
+        .navigationTitle(Text("Subscription"))
+    }
+}
+
+#Preview {
+    CooklePreview { _ in
+        NavigationStack {
+            SubscriptionView()
+        }
+    }
+}

--- a/Cookle/Sources/Settings/Model/SettingsContent.swift
+++ b/Cookle/Sources/Settings/Model/SettingsContent.swift
@@ -6,5 +6,6 @@
 //
 
 enum SettingsContent {
+    case subscription
     case license
 }

--- a/Cookle/Sources/Settings/View/SettingsNavigationView.swift
+++ b/Cookle/Sources/Settings/View/SettingsNavigationView.swift
@@ -8,6 +8,8 @@ struct SettingsNavigationView: View {
             SettingsSidebarView(selection: $selection)
         } detail: {
             switch selection {
+            case .subscription:
+                SubscriptionView()
             case .license:
                 LicenseView()
             case .none:

--- a/Cookle/Sources/Settings/View/SettingsNavigationView.swift
+++ b/Cookle/Sources/Settings/View/SettingsNavigationView.swift
@@ -9,7 +9,7 @@ struct SettingsNavigationView: View {
         } detail: {
             switch selection {
             case .subscription:
-                SubscriptionView()
+                StoreListView()
             case .license:
                 LicenseView()
             case .none:

--- a/Cookle/Sources/Settings/View/SettingsSidebarView.swift
+++ b/Cookle/Sources/Settings/View/SettingsSidebarView.swift
@@ -25,8 +25,12 @@ struct SettingsSidebarView: View {
 
     var body: some View {
         List(selection: $content) {
-            StoreSection()
-                .hidden(isSubscribeOn)
+            Section {
+                NavigationLink(value: SettingsContent.subscription) {
+                    Text("Subscription")
+                }
+            }
+            .hidden(isSubscribeOn)
             Section {
                 Toggle("iCloud On", isOn: $isICloudOn)
             } header: {


### PR DESCRIPTION
## Summary
- add dedicated `SubscriptionView` that uses `StoreKit`
- navigate to subscription screen from the settings sidebar
- wire subscription item into navigation
- localize text for `Subscription`

## Testing
- `pre-commit` *(fails: could not fetch SwiftLint)*

------
https://chatgpt.com/codex/tasks/task_e_6850d0fc49e48320a129aea7b3744827