### PR TITLE
Switch views to RecipeEntity

### DIFF
--- a/Cookle/Sources/AppIntent/Model/RecipeEntity+Model.swift
+++ b/Cookle/Sources/AppIntent/Model/RecipeEntity+Model.swift
@@ -1,0 +1,8 @@
+import SwiftData
+
+extension RecipeEntity {
+    func model(context: ModelContext) throws -> Recipe? {
+        let identifier = try PersistentIdentifier(base64Encoded: id)
+        return try context.fetchFirst(.recipes(.idIs(identifier)))
+    }
+}

--- a/Cookle/Sources/Common/Model/CookleImagePlayground.swift
+++ b/Cookle/Sources/Common/Model/CookleImagePlayground.swift
@@ -6,6 +6,7 @@
 //
 
 import ImagePlayground
+import AppIntents
 import SwiftUI
 
 enum CookleImagePlayground {
@@ -22,7 +23,7 @@ extension View {
     @ViewBuilder
     func cookleImagePlayground(
         isPresented: Binding<Bool>,
-        recipe: Recipe?,
+        recipe: RecipeEntity?,
         onCompletion: @escaping (Data) -> Void,
         onCancellation: (() -> Void)? = nil
     ) -> some View {
@@ -37,9 +38,9 @@ extension View {
                     concepts.append(
                         .text(recipe.name)
                     )
-                    recipe.ingredients?.forEach { ingredient in
+                    recipe.ingredients.forEach { ingredient in
                         concepts.append(
-                            .text(ingredient.value)
+                            .text(ingredient)
                         )
                     }
                     recipe.steps.forEach { step in

--- a/Cookle/Sources/Diary/View/DiaryFormRecipeListView.swift
+++ b/Cookle/Sources/Diary/View/DiaryFormRecipeListView.swift
@@ -11,16 +11,16 @@ import SwiftUI
 struct DiaryFormRecipeListView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @Query(.recipes(.all)) private var recipes: [Recipe]
+    @BridgeQuery(.recipes(.all)) private var recipes: [RecipeEntity]
 
-    @Binding private var selection: Set<Recipe>
+    @Binding private var selection: Set<RecipeEntity>
 
-    @State private var temporarySelection = Set<Recipe>()
+    @State private var temporarySelection = Set<RecipeEntity>()
     @State private var searchText = ""
 
     private let type: DiaryObjectType
 
-    init(selection: Binding<Set<Recipe>> = .constant([]), type: DiaryObjectType) {
+    init(selection: Binding<Set<RecipeEntity>> = .constant([]), type: DiaryObjectType) {
         _selection = selection
         _temporarySelection = .init(initialValue: selection.wrappedValue)
         self.type = type

--- a/Cookle/Sources/Diary/View/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/View/DiaryFormView.swift
@@ -15,9 +15,9 @@ struct DiaryFormView: View {
     @Environment(Diary.self) private var diary: Diary?
 
     @State private var date = Date.now
-    @State private var breakfasts = Set<Recipe>()
-    @State private var lunches = Set<Recipe>()
-    @State private var dinners = Set<Recipe>()
+    @State private var breakfasts = Set<RecipeEntity>()
+    @State private var lunches = Set<RecipeEntity>()
+    @State private var dinners = Set<RecipeEntity>()
     @State private var note = ""
 
     var body: some View {

--- a/Cookle/Sources/Diary/View/DiaryNavigationView.swift
+++ b/Cookle/Sources/Diary/View/DiaryNavigationView.swift
@@ -12,7 +12,7 @@ struct DiaryNavigationView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var diary: Diary?
-    @State private var recipe: Recipe?
+    @State private var recipe: RecipeEntity?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Diary/View/DiaryView.swift
+++ b/Cookle/Sources/Diary/View/DiaryView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct DiaryView: View {
     @Environment(Diary.self) private var diary
 
-    @Binding private var recipe: Recipe?
+    @Binding private var recipe: RecipeEntity?
 
-    init(selection: Binding<Recipe?> = .constant(nil)) {
+    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
         _recipe = selection
     }
 
@@ -22,7 +22,7 @@ struct DiaryView: View {
                 if let recipes = diary.objects?
                     .filter({ $0.type == type })
                     .sorted()
-                    .compactMap(\.recipe),
+                    .compactMap({ RecipeEntity($0.recipe) }),
                    recipes.isNotEmpty {
                     Section {
                         ForEach(recipes) { recipe in

--- a/Cookle/Sources/Photo/View/PhotoNavigationView.swift
+++ b/Cookle/Sources/Photo/View/PhotoNavigationView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PhotoNavigationView: View {
     @State private var photo: Photo?
-    @State private var recipe: Recipe?
+    @State private var recipe: RecipeEntity?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Photo/View/PhotoView.swift
+++ b/Cookle/Sources/Photo/View/PhotoView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct PhotoView: View {
     @Environment(Photo.self) private var photo
 
-    @Binding private var recipe: Recipe?
+    @Binding private var recipe: RecipeEntity?
 
     @State private var isPhotoDetailPresented = false
 
-    init(selection: Binding<Recipe?> = .constant(nil)) {
+    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
         _recipe = selection
     }
 
@@ -36,7 +36,7 @@ struct PhotoView: View {
                 }
             }
             Section {
-                ForEach(photo.recipes.orEmpty) { recipe in
+                ForEach(photo.recipes.orEmpty.compactMap(RecipeEntity.init)) { recipe in
                     NavigationLink(value: recipe) {
                         RecipeLabel()
                             .labelStyle(.titleOnly)

--- a/Cookle/Sources/Recipe/Component/CreateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Component/CreateRecipeButton.swift
@@ -12,7 +12,7 @@ struct CreateRecipeButton: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.requestReview) private var requestReview
 
-    @State private var recipe: Recipe?
+    @State private var recipe: RecipeEntity?
     @State private var isConfirmationDialogPresented = false
     @State private var isImagePlaygroundPresented = false
 
@@ -49,7 +49,7 @@ struct CreateRecipeButton: View {
 
     var body: some View {
         Button {
-            recipe = Recipe.create(
+            if let model = Recipe.create(
                 context: context,
                 name: name,
                 photos: zip(photos.indices, photos).map { index, element in
@@ -71,8 +71,10 @@ struct CreateRecipeButton: View {
                     return .create(context: context, value: $0)
                 },
                 note: note
-            )
-            if recipe?.photos?.isEmpty == true,
+            ) {
+                recipe = RecipeEntity(model)
+            }
+            if recipe?.photos.isEmpty == true,
                CookleImagePlayground.isSupported {
                 isConfirmationDialogPresented = true
             } else {
@@ -117,8 +119,9 @@ struct CreateRecipeButton: View {
             isPresented: $isImagePlaygroundPresented,
             recipe: recipe
         ) { data in
-            if let recipe {
-                recipe.update(
+            if let recipe,
+               let model = try? recipe.model(context: context) {
+                model.update(
                     name: recipe.name,
                     photos: [
                         .create(
@@ -132,9 +135,9 @@ struct CreateRecipeButton: View {
                     ],
                     servingSize: recipe.servingSize,
                     cookingTime: recipe.cookingTime,
-                    ingredients: recipe.ingredientObjects ?? [],
+                    ingredients: model.ingredientObjects ?? [],
                     steps: recipe.steps,
-                    categories: recipe.categories ?? [],
+                    categories: model.categories ?? [],
                     note: recipe.note
                 )
             }

--- a/Cookle/Sources/Recipe/Component/DeleteRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Component/DeleteRecipeButton.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct DeleteRecipeButton: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
+    @Environment(\.modelContext) private var context
 
     @State private var isPresented = false
 
@@ -30,7 +31,9 @@ struct DeleteRecipeButton: View {
             isPresented: $isPresented
         ) {
             Button("Delete", role: .destructive) {
-                recipe.delete()
+                if let model = try? recipe.model(context: context) {
+                    model.delete()
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Cookle/Sources/Recipe/Component/DuplicateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Component/DuplicateRecipeButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DuplicateRecipeButton: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     @State private var isPresented = false
 

--- a/Cookle/Sources/Recipe/Component/EditRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Component/EditRecipeButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EditRecipeButton: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     @State private var isPresented = false
 

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeCategoriesSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeCategoriesSection.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 
 struct RecipeCategoriesSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
+    @Environment(\.modelContext) private var context
 
     var body: some View {
-        if let categories = recipe.categories,
+        if let categories = try? recipe.model(context: context)?.categories,
+           let categories = categories,
            categories.isNotEmpty {
             Section {
                 ForEach(categories) {
@@ -28,7 +30,7 @@ struct RecipeCategoriesSection: View {
     CooklePreview { preview in
         List {
             RecipeCategoriesSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeCookingTimeSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeCookingTimeSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeCookingTimeSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     var body: some View {
         Section {
@@ -24,7 +24,7 @@ struct RecipeCookingTimeSection: View {
     CooklePreview { preview in
         List {
             RecipeCookingTimeSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeCreatedAtSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeCreatedAtSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeCreatedAtSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     var body: some View {
         Section {
@@ -23,7 +23,7 @@ struct RecipeCreatedAtSection: View {
     CooklePreview { preview in
         List {
             RecipeCreatedAtSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeDiariesSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeDiariesSection.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 
 struct RecipeDiariesSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
+    @Environment(\.modelContext) private var context
 
     var body: some View {
-        if let diaries = recipe.diaries,
+        if let diaries = try? recipe.model(context: context)?.diaries,
+           let diaries = diaries,
            diaries.isNotEmpty {
             Section {
                 ForEach(diaries.sorted { $0.date > $1.date }) {
@@ -28,7 +30,7 @@ struct RecipeDiariesSection: View {
     CooklePreview { preview in
         List {
             RecipeDiariesSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeIngredientsSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeIngredientsSection.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 
 struct RecipeIngredientsSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
+    @Environment(\.modelContext) private var context
 
     var body: some View {
-        if let objects = recipe.ingredientObjects,
+        if let objects = try? recipe.model(context: context)?.ingredientObjects,
+           let objects = objects,
            objects.isNotEmpty {
             Section {
                 ForEach(objects.sorted()) { object in
@@ -33,7 +35,7 @@ struct RecipeIngredientsSection: View {
     List {
         CooklePreview { preview in
             RecipeIngredientsSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeNoteSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeNoteSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeNoteSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     var body: some View {
         Section {
@@ -24,7 +24,7 @@ struct RecipeNoteSection: View {
     CooklePreview { preview in
         List {
             RecipeNoteSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipePhotosSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipePhotosSection.swift
@@ -8,17 +8,19 @@
 import SwiftUI
 
 struct RecipePhotosSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
+    @Environment(\.modelContext) private var context
 
     @State private var selectedPhoto: Photo?
 
     var body: some View {
-        if let objects = recipe.photoObjects,
-           objects.isNotEmpty {
+        if let objects = try? recipe.model(context: context)?.photoObjects,
+           let photoObjects = objects,
+           photoObjects.isNotEmpty {
             Section {
                 ScrollView(.horizontal) {
                     LazyHStack {
-                        ForEach(objects.sorted()) { photoObject in
+                        ForEach(photoObjects.sorted()) { photoObject in
                             if let photo = photoObject.photo,
                                let image = UIImage(data: photo.data) {
                                 Button {
@@ -41,7 +43,7 @@ struct RecipePhotosSection: View {
             }
             .fullScreenCover(item: $selectedPhoto) { photo in
                 PhotoDetailNavigationView(
-                    photos: objects.sorted().compactMap(\.photo),
+                    photos: photoObjects.sorted().compactMap(\.photo),
                     initialValue: photo
                 )
             }
@@ -53,7 +55,7 @@ struct RecipePhotosSection: View {
     CooklePreview { preview in
         List {
             RecipePhotosSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeServingSizeSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeServingSizeSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeServingSizeSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     var body: some View {
         Section {
@@ -24,7 +24,7 @@ struct RecipeServingSizeSection: View {
     CooklePreview { preview in
         List {
             RecipeServingSizeSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeStepsSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeStepsSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeStepsSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     var body: some View {
         Section {
@@ -31,7 +31,7 @@ struct RecipeStepsSection: View {
     CooklePreview { preview in
         List {
             RecipeStepsSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/Recipe/RecipeUpdatedAtSection.swift
+++ b/Cookle/Sources/Recipe/Component/Recipe/RecipeUpdatedAtSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeUpdatedAtSection: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     var body: some View {
         Section {
@@ -23,7 +23,7 @@ struct RecipeUpdatedAtSection: View {
     CooklePreview { preview in
         List {
             RecipeUpdatedAtSection()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Recipe/Component/RecipeForm/RecipeFormPhotosSection.swift
+++ b/Cookle/Sources/Recipe/Component/RecipeForm/RecipeFormPhotosSection.swift
@@ -9,7 +9,7 @@ import PhotosUI
 import SwiftUI
 
 struct RecipeFormPhotosSection: View {
-    @Environment(Recipe.self) private var recipe: Recipe?
+    @Environment(RecipeEntity.self) private var recipe: RecipeEntity?
     @Environment(\.editMode) private var editMode
 
     @Binding private var photos: [PhotoData]
@@ -108,9 +108,7 @@ struct RecipeFormPhotosSection: View {
             Text("Photos")
         }
         .onChange(of: photosPickerItems) {
-            photos = (recipe?.photos).orEmpty.map {
-                .init(data: $0.data, source: $0.source)
-            }
+            photos = recipe?.photos.map { .init(data: $0, source: .photosPicker) } ?? []
             Task {
                 for item in photosPickerItems {
                     guard let data = try? await item.loadTransferable(type: Data.self) else {

--- a/Cookle/Sources/Recipe/Component/RecipeLabel.swift
+++ b/Cookle/Sources/Recipe/Component/RecipeLabel.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct RecipeLabel: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
+    @Environment(\.modelContext) private var context
 
     @State private var isEditPresented = false
     @State private var isDuplicatePresented = false
@@ -12,23 +13,21 @@ struct RecipeLabel: View {
             VStack(alignment: .leading) {
                 Text(recipe.name)
                 Text(
-                    recipe.ingredientObjects.orEmpty.sorted().compactMap {
-                        $0.ingredient?.value
-                    }.joined(separator: ", ")
+                    recipe.ingredients.joined(separator: ", ")
                 )
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 Text(
-                    recipe.categories.orEmpty.map(\.value).joined(separator: ", ")
+                    recipe.categories.joined(separator: ", ")
                 )
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
             }
         } icon: {
-            if let photo = recipe.photoObjects?.min()?.photo,
-               let image = UIImage(data: photo.data) {
+            if let data = recipe.photos.first,
+               let image = UIImage(data: data) {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFit()
@@ -56,7 +55,9 @@ struct RecipeLabel: View {
             isPresented: $isDeletePresented
         ) {
             Button("Delete", role: .destructive) {
-                recipe.delete()
+                if let model = try? recipe.model(context: context) {
+                    model.delete()
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Cookle/Sources/Recipe/Component/UpdateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Component/UpdateRecipeButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct UpdateRecipeButton: View {
-    @Environment(Recipe.self) private var recipe: Recipe
+    @Environment(RecipeEntity.self) private var recipe: RecipeEntity
     @Environment(\.modelContext) private var context
     @Environment(\.dismiss) private var dismiss
     @Environment(\.requestReview) private var requestReview
@@ -46,7 +46,8 @@ struct UpdateRecipeButton: View {
 
     var body: some View {
         Button {
-            recipe.update(
+            guard let model = try? recipe.model(context: context) else { return }
+            model.update(
                 name: name,
                 photos: zip(photos.indices, photos).map { index, element in
                     .create(context: context, photoData: element, order: index + 1)

--- a/Cookle/Sources/Recipe/View/RecipeListView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeListView.swift
@@ -12,13 +12,13 @@ import SwiftUtilities
 struct RecipeListView: View {
     @Environment(\.isPresented) private var isPresented
 
-    @Query private var recipes: [Recipe]
+    @BridgeQuery private var recipes: [RecipeEntity]
 
-    @Binding private var recipe: Recipe?
+    @Binding private var recipe: RecipeEntity?
 
     @State private var searchText = ""
 
-    init(selection: Binding<Recipe?> = .constant(nil), descriptor: FetchDescriptor<Recipe> = .recipes(.all)) {
+    init(selection: Binding<RecipeEntity?> = .constant(nil), descriptor: FetchDescriptor<Recipe> = .recipes(.all)) {
         _recipe = selection
         _recipes = .init(descriptor)
     }

--- a/Cookle/Sources/Recipe/View/RecipeNavigationView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeNavigationView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct RecipeNavigationView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    @State private var recipe: Recipe?
+    @State private var recipe: RecipeEntity?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Recipe/View/RecipeView.swift
+++ b/Cookle/Sources/Recipe/View/RecipeView.swift
@@ -9,7 +9,7 @@ import SwiftData
 import SwiftUI
 
 struct RecipeView: View {
-    @Environment(Recipe.self) private var recipe
+    @Environment(RecipeEntity.self) private var recipe
 
     @AppStorage(.lastOpenedRecipeID) private var lastOpenedRecipeID
     @AppStorage(.isSubscribeOn) private var isSubscribeOn
@@ -54,7 +54,7 @@ struct RecipeView: View {
     CooklePreview { preview in
         NavigationStack {
             RecipeView()
-                .environment(preview.recipes[0])
+                .environment(RecipeEntity(preview.recipes[0])!)
         }
     }
 }

--- a/Cookle/Sources/Search/View/SearchNavigationView.swift
+++ b/Cookle/Sources/Search/View/SearchNavigationView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SearchNavigationView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    @State private var recipe: Recipe?
+    @State private var recipe: RecipeEntity?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Search/View/SearchView.swift
+++ b/Cookle/Sources/Search/View/SearchView.swift
@@ -13,13 +13,13 @@ struct SearchView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.isPresented) private var isPresented
 
-    @Binding private var recipe: Recipe?
+    @Binding private var recipe: RecipeEntity?
 
-    @State private var recipes = [Recipe]()
+    @State private var recipes = [RecipeEntity]()
     @State private var searchText = ""
     @State private var isFocused = false
 
-    init(selection: Binding<Recipe?> = .constant(nil)) {
+    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
         _recipe = selection
     }
 
@@ -69,7 +69,7 @@ struct SearchView: View {
         }
         .onChange(of: searchText) {
             do {
-                var recipes = try context.fetch(
+                var models = try context.fetch(
                     .recipes(.nameContains(searchText))
                 )
                 let ingredients = try context.fetch(
@@ -82,10 +82,10 @@ struct SearchView: View {
                         ? .categories(.valueIs(searchText))
                         : .categories(.valueContains(searchText))
                 )
-                recipes += ingredients.flatMap(\.recipes.orEmpty)
-                recipes += categories.flatMap(\.recipes.orEmpty)
-                recipes = Array(Set(recipes))
-                self.recipes = recipes
+                models += ingredients.flatMap(\.recipes.orEmpty)
+                models += categories.flatMap(\.recipes.orEmpty)
+                models = Array(Set(models))
+                self.recipes = models.compactMap(RecipeEntity.init)
             } catch {}
         }
     }

--- a/Cookle/Sources/Tag/View/TagNavigationView.swift
+++ b/Cookle/Sources/Tag/View/TagNavigationView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TagNavigationView<T: Tag>: View {
     @State private var tag: T?
-    @State private var recipe: Recipe?
+    @State private var recipe: RecipeEntity?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Tag/View/TagView.swift
+++ b/Cookle/Sources/Tag/View/TagView.swift
@@ -10,16 +10,16 @@ import SwiftUI
 struct TagView<T: Tag>: View {
     @Environment(T.self) private var tag
 
-    @Binding private var recipe: Recipe?
+    @Binding private var recipe: RecipeEntity?
 
-    init(selection: Binding<Recipe?> = .constant(nil)) {
+    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
         _recipe = selection
     }
 
     var body: some View {
         List(selection: $recipe) {
             Section {
-                ForEach(tag.recipes.orEmpty) { recipe in
+                ForEach(tag.recipes.orEmpty.compactMap(RecipeEntity.init)) { recipe in
                     NavigationLink(value: recipe) {
                         RecipeLabel()
                             .labelStyle(.titleAndLargeIcon)


### PR DESCRIPTION
## Summary
- add ability to fetch model from `RecipeEntity`
- switch `cookleImagePlayground` to accept `RecipeEntity`
- replace usages of `Recipe` with `RecipeEntity` in views and components
- use `BridgeQuery` to load recipe entities

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cf53f61c8320929649d0839844fd