### PR TITLE
Add voice and OCR input for recipe inference

### DIFF
--- a/Cookle/Sources/Common/Component/SpeechRecognitionView.swift
+++ b/Cookle/Sources/Common/Component/SpeechRecognitionView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct SpeechRecognitionView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var recognizer = SpeechRecognitionHelper()
+
+    let completion: (String) -> Void
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                Text(recognizer.transcript)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            HStack {
+                Button("Cancel", role: .cancel) {
+                    recognizer.stopRecording()
+                    dismiss()
+                }
+                Spacer()
+                Button("Done") {
+                    recognizer.stopRecording()
+                    completion(recognizer.transcript)
+                    dismiss()
+                }
+            }
+            .padding()
+        }
+        .onAppear {
+            try? recognizer.startRecording()
+        }
+    }
+}

--- a/Cookle/Sources/Common/Model/SpeechRecognitionHelper.swift
+++ b/Cookle/Sources/Common/Model/SpeechRecognitionHelper.swift
@@ -1,0 +1,41 @@
+import AVFoundation
+import Speech
+import SwiftUI
+
+final class SpeechRecognitionHelper: NSObject, ObservableObject {
+    @Published var transcript = ""
+
+    private let audioEngine = AVAudioEngine()
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+
+    func startRecording() throws {
+        let recognizer = SFSpeechRecognizer()
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest else { return }
+        recognitionRequest.shouldReportPartialResults = true
+        recognitionTask = recognizer?.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            if let result {
+                DispatchQueue.main.async {
+                    self?.transcript = result.bestTranscription.formattedString
+                }
+            }
+            if error != nil || result?.isFinal == true {
+                self?.stopRecording()
+            }
+        }
+        let node = audioEngine.inputNode
+        let format = node.outputFormat(forBus: 0)
+        node.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            recognitionRequest.append(buffer)
+        }
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    func stopRecording() {
+        audioEngine.stop()
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+    }
+}

--- a/Cookle/Sources/Common/Model/UIImage+RecognizedText.swift
+++ b/Cookle/Sources/Common/Model/UIImage+RecognizedText.swift
@@ -1,0 +1,14 @@
+import Vision
+import UIKit
+
+extension UIImage {
+    func recognizedText() -> String {
+        guard let cgImage = cgImage else { return "" }
+        let request = VNRecognizeTextRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage)
+        try? handler.perform([request])
+        return request.results?
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: "\n") ?? ""
+    }
+}


### PR DESCRIPTION
## Summary
- add `SpeechRecognitionHelper` to handle speech-to-text
- add `SpeechRecognitionView` for voice input
- add text recognition on images via Vision
- integrate voice and OCR options using PhotosPicker in `InferRecipeFormView`

## Testing
- `pre-commit run --files Cookle/Sources/Recipe/View/InferRecipeFormView.swift Cookle/Sources/Common/Component/SpeechRecognitionView.swift Cookle/Sources/Common/Model/SpeechRecognitionHelper.swift Cookle/Sources/Common/Model/UIImage+RecognizedText.swift` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_6854ae502bbc8320888f2f5ee4329277