### PR TITLE
Reorder AppIntent declarations

### DIFF
--- a/Cookle/Sources/Main/Intent/OpenCookleIntent.swift
+++ b/Cookle/Sources/Main/Intent/OpenCookleIntent.swift
@@ -9,6 +9,9 @@ import AppIntents
 import SwiftUtilities
 
 struct OpenCookleIntent: AppIntent, IntentPerformer {
+    typealias Input = Void
+    typealias Output = Void
+
     static var title: LocalizedStringResource {
         .init("Open Cookle")
     }
@@ -16,9 +19,6 @@ struct OpenCookleIntent: AppIntent, IntentPerformer {
     static var openAppWhenRun: Bool {
         true
     }
-
-    typealias Input = Void
-    typealias Output = Void
 
     @MainActor
     static func perform(_: Input) throws -> Output {}

--- a/Cookle/Sources/Recipe/Intent/ShowLastOpenedRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intent/ShowLastOpenedRecipeIntent.swift
@@ -11,14 +11,14 @@ import SwiftUI
 import SwiftUtilities
 
 struct ShowLastOpenedRecipeIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource {
-        .init("Show Last Opened Recipe")
-    }
-
     typealias Input = (context: ModelContext, id: PersistentIdentifier?)
     typealias Output = RecipeEntity?
 
     @Dependency(\.modelContainer) private var modelContainer
+
+    static var title: LocalizedStringResource {
+        .init("Show Last Opened Recipe")
+    }
 
     @MainActor
     private static func recipe(_ input: Input) throws -> Recipe? {

--- a/Cookle/Sources/Recipe/Intent/ShowRandomRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intent/ShowRandomRecipeIntent.swift
@@ -11,14 +11,14 @@ import SwiftUI
 import SwiftUtilities
 
 struct ShowRandomRecipeIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource {
-        .init("Show Random Recipe")
-    }
-
     typealias Input = ModelContext
     typealias Output = RecipeEntity?
 
     @Dependency(\.modelContainer) private var modelContainer
+
+    static var title: LocalizedStringResource {
+        .init("Show Random Recipe")
+    }
 
     @MainActor
     private static func recipe(context: ModelContext) throws -> Recipe? {

--- a/Cookle/Sources/Search/Intent/ShowSearchResultIntent.swift
+++ b/Cookle/Sources/Search/Intent/ShowSearchResultIntent.swift
@@ -10,17 +10,17 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowSearchResultIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource {
-        .init("Show Search Result")
-    }
+    typealias Input = (context: ModelContext, text: String)
+    typealias Output = [RecipeEntity]
 
     @Parameter(title: "Search Text")
     private var searchText: String
 
-    typealias Input = (context: ModelContext, text: String)
-    typealias Output = [RecipeEntity]
-
     @Dependency(\.modelContainer) private var modelContainer
+
+    static var title: LocalizedStringResource {
+        .init("Show Search Result")
+    }
 
     @MainActor
     static func perform(_ input: Input) throws -> Output {


### PR DESCRIPTION
## Summary
- ensure `AppIntent` structs follow a consistent declaration order

## Testing
- `swiftlint --version` *(fails: cannot execute binary file)*
- `pre-commit run --files Cookle/Sources/Main/Intent/OpenCookleIntent.swift Cookle/Sources/Recipe/Intent/ShowLastOpenedRecipeIntent.swift Cookle/Sources/Recipe/Intent/ShowRandomRecipeIntent.swift Cookle/Sources/Search/Intent/ShowSearchResultIntent.swift` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550cf973048320b69c25475f109c54