### PR TITLE
Remove static model context references

### DIFF
--- a/Cookle/Sources/Recipe/Intent/ShowRandomRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intent/ShowRandomRecipeIntent.swift
@@ -6,6 +6,7 @@
 //
 
 import AppIntents
+import SwiftData
 import SwiftUI
 import SwiftUtilities
 
@@ -14,17 +15,19 @@ struct ShowRandomRecipeIntent: AppIntent, IntentPerformer {
         .init("Show Random Recipe")
     }
 
-    typealias Input = Void
+    typealias Input = ModelContext
     typealias Output = RecipeEntity?
 
+    @Dependency(\.modelContainer) private var modelContainer
+
     @MainActor
-    private static func recipe() throws -> Recipe? {
-        try CookleIntents.context.fetchRandom(.recipes(.all))
+    private static func recipe(context: ModelContext) throws -> Recipe? {
+        try context.fetchRandom(.recipes(.all))
     }
 
     @MainActor
-    static func perform(_: Input) throws -> Output {
-        guard let recipe = try recipe() else {
+    static func perform(_ input: Input) throws -> Output {
+        guard let recipe = try recipe(context: input) else {
             return nil
         }
         return RecipeEntity(recipe)
@@ -32,7 +35,7 @@ struct ShowRandomRecipeIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
-        guard let recipe = try Self.recipe() else {
+        guard let recipe = try Self.recipe(context: modelContainer.mainContext) else {
             return .result(dialog: "Not Found")
         }
         return .result(dialog: .init(stringLiteral: recipe.name)) {

--- a/Cookle/Sources/Recipe/Model/RecipeEntityQuery.swift
+++ b/Cookle/Sources/Recipe/Model/RecipeEntityQuery.swift
@@ -2,11 +2,14 @@ import AppIntents
 import SwiftData
 
 struct RecipeEntityQuery: EntityStringQuery {
+    @Dependency(\.modelContainer) private var modelContainer
     @MainActor
     func entities(for identifiers: [RecipeEntity.ID]) throws -> [RecipeEntity] {
         try identifiers.compactMap { id in
             let persistentIdentifier = try PersistentIdentifier(base64Encoded: id)
-            guard let recipe = try CookleIntents.context.fetchFirst(.recipes(.idIs(persistentIdentifier))) else {
+            guard let recipe = try modelContainer.mainContext.fetchFirst(
+                .recipes(.idIs(persistentIdentifier))
+            ) else {
                 return nil
             }
             return RecipeEntity(recipe)
@@ -15,14 +18,14 @@ struct RecipeEntityQuery: EntityStringQuery {
 
     @MainActor
     func entities(matching string: String) throws -> [RecipeEntity] {
-        try CookleIntents.context.fetch(
+        try modelContainer.mainContext.fetch(
             .recipes(.nameContains(string))
         ).compactMap(RecipeEntity.init)
     }
 
     @MainActor
     func suggestedEntities() throws -> [RecipeEntity] {
-        try CookleIntents.context.fetch(
+        try modelContainer.mainContext.fetch(
             .recipes(.all)
         ).compactMap(RecipeEntity.init)
     }


### PR DESCRIPTION
## Summary
- inject `ModelContainer` via `@Dependency` in intents
- update functions to accept `ModelContext`
- use injected context in `RecipeEntityQuery`
- pass `(context:id:)` tuple to `ShowLastOpenedRecipeIntent` static calls
- revise input types for random and search intents

## Testing
- `swiftlint --fix --format --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6854fc7ce2188320ac3b3d287dd79479