### PR TITLE
Refactor model creation API

### DIFF
--- a/Cookle/Sources/Debug/Models/CooklePreviewStore.swift
+++ b/Cookle/Sources/Debug/Models/CooklePreviewStore.swift
@@ -31,58 +31,60 @@ final class CooklePreviewStore {
             && !categories.isEmpty
     }
 
-    func prepare(_ context: ModelContext) async {
-        _ = try! await createPreviewDiaries(context, isPreview: true)
+    @MainActor
+    func prepare(_ container: ModelContainer) async {
+        _ = try! await createPreviewDiaries(container, isPreview: true)
         while !isReady {
             try! await Task.sleep(for: .seconds(0.2))
-            diaries = try! context.fetch(.diaries(.all))
-            diaryObjects = try! context.fetch(.diaryObjects(.all))
-            recipes = try! context.fetch(.recipes(.all))
-            photos = try! context.fetch(.photos(.all))
-            photoObjects = try! context.fetch(.photoObjects(.all))
-            ingredients = try! context.fetch(.ingredients(.all))
-            ingredientObjects = try! context.fetch(.ingredientObjects(.all))
-            categories = try! context.fetch(.categories(.all))
+            diaries = try! container.mainContext.fetch(.diaries(.all))
+            diaryObjects = try! container.mainContext.fetch(.diaryObjects(.all))
+            recipes = try! container.mainContext.fetch(.recipes(.all))
+            photos = try! container.mainContext.fetch(.photos(.all))
+            photoObjects = try! container.mainContext.fetch(.photoObjects(.all))
+            ingredients = try! container.mainContext.fetch(.ingredients(.all))
+            ingredientObjects = try! container.mainContext.fetch(.ingredientObjects(.all))
+            categories = try! container.mainContext.fetch(.categories(.all))
         }
     }
 
-    func createPreviewDiaries(_ context: ModelContext, isPreview: Bool = false) async throws -> [Diary] {
-        let pancakes = try await cookPancakes(context, isPreview: isPreview)
-        let chickenStirFry = try await cookChickenStirFry(context, isPreview: isPreview)
-        let vegetableSoup = try await cookVegetableSoup(context, isPreview: isPreview)
-        let spaghettiCarbonara = try await cookSpaghettiCarbonara(context, isPreview: isPreview)
-        let beefStew = try await cookBeefStew(context, isPreview: isPreview)
+    @MainActor
+    func createPreviewDiaries(_ container: ModelContainer, isPreview: Bool = false) async throws -> [Diary] {
+        let pancakes = try await cookPancakes(container, isPreview: isPreview)
+        let chickenStirFry = try await cookChickenStirFry(container, isPreview: isPreview)
+        let vegetableSoup = try await cookVegetableSoup(container, isPreview: isPreview)
+        let spaghettiCarbonara = try await cookSpaghettiCarbonara(container, isPreview: isPreview)
+        let beefStew = try await cookBeefStew(container, isPreview: isPreview)
         return (0..<10).map { i in
             .create(
-                context: context,
+                container: container,
                 date: .now.addingTimeInterval(TimeInterval(-i * 8) * 24 * 60 * 60),
                 objects: [
                     .create(
-                        context: context,
+                        container: container,
                         recipe: pancakes,
                         type: .breakfast,
                         order: 1
                     ),
                     .create(
-                        context: context,
+                        container: container,
                         recipe: chickenStirFry,
                         type: .lunch,
                         order: 1
                     ),
                     .create(
-                        context: context,
+                        container: container,
                         recipe: vegetableSoup,
                         type: .lunch,
                         order: 2
                     ),
                     .create(
-                        context: context,
+                        container: container,
                         recipe: spaghettiCarbonara,
                         type: .dinner,
                         order: 1
                     ),
                     .create(
-                        context: context,
+                        container: container,
                         recipe: beefStew,
                         type: .dinner,
                         order: 2
@@ -103,23 +105,24 @@ final class CooklePreviewStore {
         }
     }
 
-    private func cookSpaghettiCarbonara(_ context: ModelContext, isPreview: Bool) async throws -> Recipe {
-        .create(
-            context: context,
+    @MainActor
+    private func cookSpaghettiCarbonara(_ container: ModelContainer, isPreview: Bool) async throws -> Recipe {
+        return .create(
+            container: container,
             name: "Spaghetti Carbonara",
             photos: [
-                isPreview ? createPhotoObject(context, systemName: "frying.pan", order: 1) : try await createPhotoObject(context, name: "SpaghettiCarbonara1", order: 1),
-                isPreview ? createPhotoObject(context, systemName: "oval.portrait", order: 2) : try await createPhotoObject(context, name: "SpaghettiCarbonara2", order: 2)
+                isPreview ? createPhotoObject(container, systemName: "frying.pan", order: 1) : try await createPhotoObject(container, name: "SpaghettiCarbonara1", order: 1),
+                isPreview ? createPhotoObject(container, systemName: "oval.portrait", order: 2) : try await createPhotoObject(container, name: "SpaghettiCarbonara2", order: 2)
             ],
             servingSize: 2,
             cookingTime: 30,
             ingredients: [
-                .create(context: context, ingredient: "Spaghetti", amount: "200g", order: 1),
-                .create(context: context, ingredient: "Eggs", amount: "2", order: 2),
-                .create(context: context, ingredient: "Parmesan cheese", amount: "50g", order: 3),
-                .create(context: context, ingredient: "Pancetta", amount: "100g", order: 4),
-                .create(context: context, ingredient: "Black pepper", amount: "to taste", order: 5),
-                .create(context: context, ingredient: "Salt", amount: "to taste", order: 6)
+                .create(container: container, ingredient: "Spaghetti", amount: "200g", order: 1),
+                .create(container: container, ingredient: "Eggs", amount: "2", order: 2),
+                .create(container: container, ingredient: "Parmesan cheese", amount: "50g", order: 3),
+                .create(container: container, ingredient: "Pancetta", amount: "100g", order: 4),
+                .create(container: container, ingredient: "Black pepper", amount: "to taste", order: 5),
+                .create(container: container, ingredient: "Salt", amount: "to taste", order: 6)
             ],
             steps: [
                 "Boil water in a large pot and add salt.",
@@ -130,33 +133,34 @@ final class CooklePreviewStore {
                 "Season with black pepper and serve immediately."
             ],
             categories: [
-                .create(context: context, value: "Italian")
+                .create(container: container, value: "Italian")
             ],
             note: "Use freshly grated Parmesan for the best flavor."
         )
     }
 
-    private func cookBeefStew(_ context: ModelContext, isPreview: Bool) async throws -> Recipe {
-        .create(
-            context: context,
+    @MainActor
+    private func cookBeefStew(_ container: ModelContainer, isPreview: Bool) async throws -> Recipe {
+        return .create(
+            container: container,
             name: "Beef Stew",
             photos: [
-                isPreview ? createPhotoObject(context, systemName: "fork.knife", order: 1) : try await createPhotoObject(context, name: "BeefStew1", order: 1),
-                isPreview ? createPhotoObject(context, systemName: "wineglass", order: 2) : try await createPhotoObject(context, name: "BeefStew2", order: 2)
+                isPreview ? createPhotoObject(container, systemName: "fork.knife", order: 1) : try await createPhotoObject(container, name: "BeefStew1", order: 1),
+                isPreview ? createPhotoObject(container, systemName: "wineglass", order: 2) : try await createPhotoObject(container, name: "BeefStew2", order: 2)
             ],
             servingSize: 6,
             cookingTime: 120,
             ingredients: [
-                .create(context: context, ingredient: "Beef chuck", amount: "1 kg", order: 1),
-                .create(context: context, ingredient: "Carrots", amount: "3", order: 2),
-                .create(context: context, ingredient: "Potatoes", amount: "4", order: 3),
-                .create(context: context, ingredient: "Onions", amount: "2", order: 4),
-                .create(context: context, ingredient: "Beef broth", amount: "4 cups", order: 5),
-                .create(context: context, ingredient: "Tomato paste", amount: "2 tbsp", order: 6),
-                .create(context: context, ingredient: "Flour", amount: "1/4 cup", order: 7),
-                .create(context: context, ingredient: "Salt", amount: "to taste", order: 8),
-                .create(context: context, ingredient: "Black pepper", amount: "to taste", order: 9),
-                .create(context: context, ingredient: "Olive oil", amount: "2 tbsp", order: 10)
+                .create(container: container, ingredient: "Beef chuck", amount: "1 kg", order: 1),
+                .create(container: container, ingredient: "Carrots", amount: "3", order: 2),
+                .create(container: container, ingredient: "Potatoes", amount: "4", order: 3),
+                .create(container: container, ingredient: "Onions", amount: "2", order: 4),
+                .create(container: container, ingredient: "Beef broth", amount: "4 cups", order: 5),
+                .create(container: container, ingredient: "Tomato paste", amount: "2 tbsp", order: 6),
+                .create(container: container, ingredient: "Flour", amount: "1/4 cup", order: 7),
+                .create(container: container, ingredient: "Salt", amount: "to taste", order: 8),
+                .create(container: container, ingredient: "Black pepper", amount: "to taste", order: 9),
+                .create(container: container, ingredient: "Olive oil", amount: "2 tbsp", order: 10)
             ],
             steps: [
                 "Cut the beef into large chunks and season with salt and pepper.",
@@ -169,32 +173,33 @@ final class CooklePreviewStore {
                 "Season with salt and pepper to taste, and serve hot."
             ],
             categories: [
-                .create(context: context, value: "Comfort Food")
+                .create(container: container, value: "Comfort Food")
             ],
             note: "This stew is even better the next day."
         )
     }
 
-    private func cookChickenStirFry(_ context: ModelContext, isPreview: Bool) async throws -> Recipe {
-        .create(
-            context: context,
+    @MainActor
+    private func cookChickenStirFry(_ container: ModelContainer, isPreview: Bool) async throws -> Recipe {
+        return .create(
+            container: container,
             name: "Chicken Stir Fry",
             photos: [
-                isPreview ? createPhotoObject(context, systemName: "bird", order: 1) : try await createPhotoObject(context, name: "ChickenStirFry1", order: 1),
-                isPreview ? createPhotoObject(context, systemName: "tree", order: 2) : try await createPhotoObject(context, name: "ChickenStirFry2", order: 2)
+                isPreview ? createPhotoObject(container, systemName: "bird", order: 1) : try await createPhotoObject(container, name: "ChickenStirFry1", order: 1),
+                isPreview ? createPhotoObject(container, systemName: "tree", order: 2) : try await createPhotoObject(container, name: "ChickenStirFry2", order: 2)
             ],
             servingSize: 4,
             cookingTime: 20,
             ingredients: [
-                .create(context: context, ingredient: "Chicken breast", amount: "500g", order: 1),
-                .create(context: context, ingredient: "Bell peppers", amount: "2", order: 2),
-                .create(context: context, ingredient: "Broccoli", amount: "1 head", order: 3),
-                .create(context: context, ingredient: "Soy sauce", amount: "3 tbsp", order: 4),
-                .create(context: context, ingredient: "Garlic", amount: "2 cloves", order: 5),
-                .create(context: context, ingredient: "Ginger", amount: "1 inch", order: 6),
-                .create(context: context, ingredient: "Vegetable oil", amount: "2 tbsp", order: 7),
-                .create(context: context, ingredient: "Cornstarch", amount: "1 tbsp", order: 8),
-                .create(context: context, ingredient: "Water", amount: "1/2 cup", order: 9)
+                .create(container: container, ingredient: "Chicken breast", amount: "500g", order: 1),
+                .create(container: container, ingredient: "Bell peppers", amount: "2", order: 2),
+                .create(container: container, ingredient: "Broccoli", amount: "1 head", order: 3),
+                .create(container: container, ingredient: "Soy sauce", amount: "3 tbsp", order: 4),
+                .create(container: container, ingredient: "Garlic", amount: "2 cloves", order: 5),
+                .create(container: container, ingredient: "Ginger", amount: "1 inch", order: 6),
+                .create(container: container, ingredient: "Vegetable oil", amount: "2 tbsp", order: 7),
+                .create(container: container, ingredient: "Cornstarch", amount: "1 tbsp", order: 8),
+                .create(container: container, ingredient: "Water", amount: "1/2 cup", order: 9)
             ],
             steps: [
                 "Cut the chicken into bite-sized pieces.",
@@ -208,33 +213,34 @@ final class CooklePreviewStore {
                 "Serve hot with rice."
             ],
             categories: [
-                .create(context: context, value: "Asian")
+                .create(container: container, value: "Asian")
             ],
             note: "You can use any vegetables you like for this stir fry."
         )
     }
 
-    private func cookVegetableSoup(_ context: ModelContext, isPreview: Bool) async throws -> Recipe {
-        .create(
-            context: context,
+    @MainActor
+    private func cookVegetableSoup(_ container: ModelContainer, isPreview: Bool) async throws -> Recipe {
+        return .create(
+            container: container,
             name: "Vegetable Soup",
             photos: [
-                isPreview ? createPhotoObject(context, systemName: "cup.and.saucer", order: 1) : try await createPhotoObject(context, name: "VegetableSoup1", order: 1),
-                isPreview ? createPhotoObject(context, systemName: "carrot", order: 2) : try await createPhotoObject(context, name: "VegetableSoup2", order: 2)
+                isPreview ? createPhotoObject(container, systemName: "cup.and.saucer", order: 1) : try await createPhotoObject(container, name: "VegetableSoup1", order: 1),
+                isPreview ? createPhotoObject(container, systemName: "carrot", order: 2) : try await createPhotoObject(container, name: "VegetableSoup2", order: 2)
             ],
             servingSize: 4,
             cookingTime: 40,
             ingredients: [
-                .create(context: context, ingredient: "Carrots", amount: "3", order: 1),
-                .create(context: context, ingredient: "Potatoes", amount: "2", order: 2),
-                .create(context: context, ingredient: "Celery", amount: "2 stalks", order: 3),
-                .create(context: context, ingredient: "Onion", amount: "1", order: 4),
-                .create(context: context, ingredient: "Garlic", amount: "2 cloves", order: 5),
-                .create(context: context, ingredient: "Vegetable broth", amount: "6 cups", order: 6),
-                .create(context: context, ingredient: "Tomatoes", amount: "2", order: 7),
-                .create(context: context, ingredient: "Salt", amount: "to taste", order: 8),
-                .create(context: context, ingredient: "Black pepper", amount: "to taste", order: 9),
-                .create(context: context, ingredient: "Olive oil", amount: "2 tbsp", order: 10)
+                .create(container: container, ingredient: "Carrots", amount: "3", order: 1),
+                .create(container: container, ingredient: "Potatoes", amount: "2", order: 2),
+                .create(container: container, ingredient: "Celery", amount: "2 stalks", order: 3),
+                .create(container: container, ingredient: "Onion", amount: "1", order: 4),
+                .create(container: container, ingredient: "Garlic", amount: "2 cloves", order: 5),
+                .create(container: container, ingredient: "Vegetable broth", amount: "6 cups", order: 6),
+                .create(container: container, ingredient: "Tomatoes", amount: "2", order: 7),
+                .create(container: container, ingredient: "Salt", amount: "to taste", order: 8),
+                .create(container: container, ingredient: "Black pepper", amount: "to taste", order: 9),
+                .create(container: container, ingredient: "Olive oil", amount: "2 tbsp", order: 10)
             ],
             steps: [
                 "Chop the carrots, potatoes, celery, onion, and tomatoes.",
@@ -247,30 +253,31 @@ final class CooklePreviewStore {
                 "Serve hot with a sprinkle of fresh herbs."
             ],
             categories: [
-                .create(context: context, value: "Healthy")
+                .create(container: container, value: "Healthy")
             ],
             note: "You can add any vegetables you have on hand."
         )
     }
 
-    private func cookPancakes(_ context: ModelContext, isPreview: Bool) async throws -> Recipe {
-        .create(
-            context: context,
+    @MainActor
+    private func cookPancakes(_ container: ModelContainer, isPreview: Bool) async throws -> Recipe {
+        return .create(
+            container: container,
             name: "Pancakes",
             photos: [
-                isPreview ? createPhotoObject(context, systemName: "birthday.cake", order: 1) : try await createPhotoObject(context, name: "Pancakes1", order: 1),
-                isPreview ? createPhotoObject(context, systemName: "mug", order: 2) : try await createPhotoObject(context, name: "Pancakes2", order: 2)
+                isPreview ? createPhotoObject(container, systemName: "birthday.cake", order: 1) : try await createPhotoObject(container, name: "Pancakes1", order: 1),
+                isPreview ? createPhotoObject(container, systemName: "mug", order: 2) : try await createPhotoObject(container, name: "Pancakes2", order: 2)
             ],
             servingSize: 4,
             cookingTime: 20,
             ingredients: [
-                .create(context: context, ingredient: "All-purpose flour", amount: "1 cup", order: 1),
-                .create(context: context, ingredient: "Milk", amount: "1 cup", order: 2),
-                .create(context: context, ingredient: "Egg", amount: "1", order: 3),
-                .create(context: context, ingredient: "Baking powder", amount: "2 tsp", order: 4),
-                .create(context: context, ingredient: "Salt", amount: "1/4 tsp", order: 5),
-                .create(context: context, ingredient: "Sugar", amount: "1 tbsp", order: 6),
-                .create(context: context, ingredient: "Butter", amount: "2 tbsp", order: 7)
+                .create(container: container, ingredient: "All-purpose flour", amount: "1 cup", order: 1),
+                .create(container: container, ingredient: "Milk", amount: "1 cup", order: 2),
+                .create(container: container, ingredient: "Egg", amount: "1", order: 3),
+                .create(container: container, ingredient: "Baking powder", amount: "2 tsp", order: 4),
+                .create(container: container, ingredient: "Salt", amount: "1/4 tsp", order: 5),
+                .create(container: container, ingredient: "Sugar", amount: "1 tbsp", order: 6),
+                .create(container: container, ingredient: "Butter", amount: "2 tbsp", order: 7)
             ],
             steps: [
                 "In a large bowl, mix together the flour, baking powder, salt, and sugar.",
@@ -281,15 +288,16 @@ final class CooklePreviewStore {
                 "Brown on both sides and serve hot."
             ],
             categories: [
-                .create(context: context, value: "Breakfast")
+                .create(container: container, value: "Breakfast")
             ],
             note: "Serve with syrup, butter, and fresh fruits."
         )
     }
 
-    private func createPhotoObject(_ context: ModelContext, systemName: String, order: Int) -> PhotoObject {
-        .create(
-            context: context,
+    @MainActor
+    private func createPhotoObject(_ container: ModelContainer, systemName: String, order: Int) -> PhotoObject {
+        return .create(
+            container: container,
             photoData: .init(
                 data: UIImage(systemName: systemName)!.withTintColor(.init(.init(uiColor: .tintColor).adjusted(by: systemName.hashValue))).jpegData(compressionQuality: 1)!,
                 source: order == 1 ? .photosPicker : .imagePlayground
@@ -298,9 +306,10 @@ final class CooklePreviewStore {
         )
     }
 
-    private func createPhotoObject(_ context: ModelContext, name: String, order: Int) async throws -> PhotoObject {
-        .create(
-            context: context,
+    @MainActor
+    private func createPhotoObject(_ container: ModelContainer, name: String, order: Int) async throws -> PhotoObject {
+        return .create(
+            container: container,
             photoData: .init(
                 data: try await URLSession.shared.data(from: .init(string: "https://raw.githubusercontent.com/muhiro12/Cookle/refs/heads/main/.Resources/\(name).png")!).0,
                 source: .photosPicker

--- a/Cookle/Sources/Debug/Models/ModelContainerPreview.swift
+++ b/Cookle/Sources/Debug/Models/ModelContainerPreview.swift
@@ -23,8 +23,8 @@ struct ModelContainerPreview<Content: View>: View {
                 .modelContainer(previewModelContainer)
         } else {
             ProgressView()
-                .task {
-                    await preview.prepare(previewModelContainer.mainContext)
+                .task { @MainActor in
+                    await preview.prepare(previewModelContainer)
                     isReady = true
                 }
         }

--- a/Cookle/Sources/Debug/Views/DebugSidebarView.swift
+++ b/Cookle/Sources/Debug/Views/DebugSidebarView.swift
@@ -77,8 +77,8 @@ struct DebugSidebarView: View {
             isPresented: $isAlertPresented
         ) {
             Button(role: .destructive) {
-                Task {
-                    _ = try? await CooklePreviewStore().createPreviewDiaries(context)
+                Task { @MainActor in
+                    _ = try? await CooklePreviewStore().createPreviewDiaries(context.container)
                 }
             } label: {
                 Text("Create")

--- a/Cookle/Sources/Diary/Models/Diary.swift
+++ b/Cookle/Sources/Diary/Models/Diary.swift
@@ -22,12 +22,13 @@ final class Diary {
 
     private init() {}
 
-    static func create(context: ModelContext,
+    @MainActor
+    static func create(container: ModelContainer,
                        date: Date,
                        objects: [DiaryObject],
                        note: String) -> Diary {
         let diary = Diary()
-        context.insert(diary)
+        container.mainContext.insert(diary)
         diary.date = date
         diary.objects = objects
         diary.recipes = objects.compactMap(\.recipe)

--- a/Cookle/Sources/Diary/Models/DiaryObject.swift
+++ b/Cookle/Sources/Diary/Models/DiaryObject.swift
@@ -26,9 +26,10 @@ final class DiaryObject: SubObject {
         self.type = type
     }
 
-    static func create(context: ModelContext, recipe: Recipe, type: DiaryObjectType, order: Int) -> DiaryObject {
+    @MainActor
+    static func create(container: ModelContainer, recipe: Recipe, type: DiaryObjectType, order: Int) -> DiaryObject {
         let object = DiaryObject(recipe: recipe, type: type)
-        context.insert(object)
+        container.mainContext.insert(object)
         object.order = order
         return object
     }

--- a/Cookle/Sources/Diary/Views/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryFormView.swift
@@ -80,24 +80,24 @@ struct DiaryFormView: View {
                         diary.update(
                             date: date,
                             objects: zip(recipes(from: breakfasts).indices, recipes(from: breakfasts)).map { index, element in
-                                .create(context: context, recipe: element, type: .breakfast, order: index + 1)
+                                .create(container: context.container, recipe: element, type: .breakfast, order: index + 1)
                             } + zip(recipes(from: lunches).indices, recipes(from: lunches)).map { index, element in
-                                .create(context: context, recipe: element, type: .lunch, order: index + 1)
+                                .create(container: context.container, recipe: element, type: .lunch, order: index + 1)
                             } + zip(recipes(from: dinners).indices, recipes(from: dinners)).map { index, element in
-                                .create(context: context, recipe: element, type: .dinner, order: index + 1)
+                                .create(container: context.container, recipe: element, type: .dinner, order: index + 1)
                             },
                             note: note
                         )
                     } else {
                         _ = Diary.create(
-                            context: context,
+                            container: context.container,
                             date: date,
                             objects: zip(recipes(from: breakfasts).indices, recipes(from: breakfasts)).map { index, element in
-                                .create(context: context, recipe: element, type: .breakfast, order: index + 1)
+                                .create(container: context.container, recipe: element, type: .breakfast, order: index + 1)
                             } + zip(recipes(from: lunches).indices, recipes(from: lunches)).map { index, element in
-                                .create(context: context, recipe: element, type: .lunch, order: index + 1)
+                                .create(container: context.container, recipe: element, type: .lunch, order: index + 1)
                             } + zip(recipes(from: dinners).indices, recipes(from: dinners)).map { index, element in
-                                .create(context: context, recipe: element, type: .dinner, order: index + 1)
+                                .create(container: context.container, recipe: element, type: .dinner, order: index + 1)
                             },
                             note: note
                         )
@@ -110,7 +110,7 @@ struct DiaryFormView: View {
             }
         }
         .interactiveDismissDisabled()
-        .task {
+        .task { @MainActor in
             date = diary?.date ?? .now
             breakfasts = recipeEntities(from: diary?.objects.orEmpty.filter {
                 $0.type == .breakfast

--- a/Cookle/Sources/Photo/Models/Photo.swift
+++ b/Cookle/Sources/Photo/Models/Photo.swift
@@ -23,9 +23,10 @@ final class Photo {
 
     private init() {}
 
-    static func create(context: ModelContext, photoData: PhotoData) -> Photo {
-        let photo = (try? context.fetchFirst(.photos(.dataIs(photoData.data)))) ?? .init()
-        context.insert(photo)
+    @MainActor
+    static func create(container: ModelContainer, photoData: PhotoData) -> Photo {
+        let photo = (try? container.mainContext.fetchFirst(.photos(.dataIs(photoData.data)))) ?? .init()
+        container.mainContext.insert(photo)
         photo.data = photoData.data
         photo.sourceID = photoData.source.rawValue
         return photo

--- a/Cookle/Sources/Photo/Models/PhotoObject.swift
+++ b/Cookle/Sources/Photo/Models/PhotoObject.swift
@@ -24,11 +24,12 @@ final class PhotoObject: SubObject {
         self.photo = photo
     }
 
-    static func create(context: ModelContext, photoData: PhotoData, order: Int) -> PhotoObject {
+    @MainActor
+    static func create(container: ModelContainer, photoData: PhotoData, order: Int) -> PhotoObject {
         let object = PhotoObject(
-            photo: .create(context: context, photoData: photoData)
+            photo: .create(container: container, photoData: photoData)
         )
-        context.insert(object)
+        container.mainContext.insert(object)
         object.order = order
         return object
     }

--- a/Cookle/Sources/Recipe/Components/CreateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/CreateRecipeButton.swift
@@ -50,10 +50,10 @@ struct CreateRecipeButton: View {
     var body: some View {
         Button {
             let model = Recipe.create(
-                context: context,
+                container: context.container,
                 name: name,
                 photos: zip(photos.indices, photos).map { index, element in
-                    .create( context: context, photoData: element, order: index + 1)
+                    .create(container: context.container, photoData: element, order: index + 1)
                 },
                 servingSize: toInt(servingSize) ?? .zero,
                 cookingTime: toInt(cookingTime) ?? .zero,
@@ -61,7 +61,7 @@ struct CreateRecipeButton: View {
                     guard !element.ingredient.isEmpty else {
                         return nil
                     }
-                    return .create(context: context, ingredient: element.ingredient, amount: element.amount, order: index + 1)
+                    return .create(container: context.container, ingredient: element.ingredient, amount: element.amount, order: index + 1)
                 },
                 steps: steps.filter {
                     !$0.isEmpty
@@ -70,7 +70,7 @@ struct CreateRecipeButton: View {
                     guard !$0.isEmpty else {
                         return nil
                     }
-                    return .create(context: context, value: $0)
+                    return .create(container: context.container, value: $0)
                 },
                 note: note
             )
@@ -126,7 +126,7 @@ struct CreateRecipeButton: View {
                     name: recipe.name,
                     photos: [
                         .create(
-                            context: context,
+                            container: context.container,
                             photoData: .init(
                                 data: data.compressed(),
                                 source: .imagePlayground

--- a/Cookle/Sources/Recipe/Components/UpdateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/UpdateRecipeButton.swift
@@ -52,7 +52,7 @@ struct UpdateRecipeButton: View {
             model.update(
                 name: name,
                 photos: zip(photos.indices, photos).map { index, element in
-                    .create(context: context, photoData: element, order: index + 1)
+                    .create(container: context.container, photoData: element, order: index + 1)
                 },
                 servingSize: toInt(servingSize) ?? .zero,
                 cookingTime: toInt(cookingTime) ?? .zero,
@@ -60,7 +60,7 @@ struct UpdateRecipeButton: View {
                     guard !element.ingredient.isEmpty else {
                         return nil
                     }
-                    return .create(context: context, ingredient: element.ingredient, amount: element.amount, order: index + 1)
+                    return .create(container: context.container, ingredient: element.ingredient, amount: element.amount, order: index + 1)
                 },
                 steps: steps.filter {
                     !$0.isEmpty
@@ -69,7 +69,7 @@ struct UpdateRecipeButton: View {
                     guard !$0.isEmpty else {
                         return nil
                     }
-                    return .create(context: context, value: $0)
+                    return .create(container: context.container, value: $0)
                 },
                 note: note
             )

--- a/Cookle/Sources/Recipe/Models/Recipe.swift
+++ b/Cookle/Sources/Recipe/Models/Recipe.swift
@@ -36,7 +36,8 @@ final class Recipe {
 
     private init() {}
 
-    static func create(context: ModelContext,
+    @MainActor
+    static func create(container: ModelContainer,
                        name: String,
                        photos: [PhotoObject],
                        servingSize: Int,
@@ -46,7 +47,7 @@ final class Recipe {
                        categories: [Category],
                        note: String) -> Recipe {
         let recipe = Recipe()
-        context.insert(recipe)
+        container.mainContext.insert(recipe)
         recipe.name = name
         recipe.photos = photos.compactMap(\.photo)
         recipe.photoObjects = photos

--- a/Cookle/Sources/Recipe/Views/RecipeFormView.swift
+++ b/Cookle/Sources/Recipe/Views/RecipeFormView.swift
@@ -139,7 +139,7 @@ struct RecipeFormView: View {
         } message: {
             Text("Are you really going to use DebugMode?")
         }
-        .task {
+        .task { @MainActor in
             guard let entity = recipe,
                   let model = try? entity.model(context: context) else {
                 return

--- a/Cookle/Sources/Tag/Models/Category.swift
+++ b/Cookle/Sources/Tag/Models/Category.swift
@@ -20,9 +20,10 @@ final class Category: Tag {
 
     private init() {}
 
-    static func create(context: ModelContext, value: String) -> Self {
-        let category = (try? context.fetchFirst(.categories(.valueIs(value)))) ?? .init()
-        context.insert(category)
+    @MainActor
+    static func create(container: ModelContainer, value: String) -> Self {
+        let category = (try? container.mainContext.fetchFirst(.categories(.valueIs(value)))) ?? .init()
+        container.mainContext.insert(category)
         category.value = value
         return category as! Self
     }

--- a/Cookle/Sources/Tag/Models/Ingredient.swift
+++ b/Cookle/Sources/Tag/Models/Ingredient.swift
@@ -22,9 +22,10 @@ final class Ingredient: Tag {
 
     private init() {}
 
-    static func create(context: ModelContext, value: String) -> Self {
-        let ingredient = (try? context.fetchFirst(.ingredients(.valueIs(value)))) ?? .init()
-        context.insert(ingredient)
+    @MainActor
+    static func create(container: ModelContainer, value: String) -> Self {
+        let ingredient = (try? container.mainContext.fetchFirst(.ingredients(.valueIs(value)))) ?? .init()
+        container.mainContext.insert(ingredient)
         ingredient.value = value
         return ingredient as! Self
     }

--- a/Cookle/Sources/Tag/Models/IngredientObject.swift
+++ b/Cookle/Sources/Tag/Models/IngredientObject.swift
@@ -25,11 +25,12 @@ final class IngredientObject: SubObject {
         self.ingredient = ingredient
     }
 
-    static func create(context: ModelContext, ingredient: String, amount: String, order: Int) -> IngredientObject {
+    @MainActor
+    static func create(container: ModelContainer, ingredient: String, amount: String, order: Int) -> IngredientObject {
         let object = IngredientObject(
-            ingredient: .create(context: context, value: ingredient)
+            ingredient: .create(container: container, value: ingredient)
         )
-        context.insert(object)
+        container.mainContext.insert(object)
         object.amount = amount
         object.order = order
         return object

--- a/Cookle/Sources/Tag/Models/Tag.swift
+++ b/Cookle/Sources/Tag/Models/Tag.swift
@@ -14,7 +14,8 @@ protocol Tag: PersistentModel {
     var createdTimestamp: Date { get }
     var modifiedTimestamp: Date { get }
 
-    static func create(context: ModelContext, value: String) -> Self
+    @MainActor
+    static func create(container: ModelContainer, value: String) -> Self
     func update(value: String)
 
     static var title: LocalizedStringKey { get }


### PR DESCRIPTION
## Summary
- update all model `create` methods to accept `ModelContainer` and reference container context directly
- mark creation helpers with `@MainActor`
- simplify preview store to use `container.mainContext` without a temporary variable
- ensure `.task` and `Task` closures run on `@MainActor`
- annotate preview helpers with `@MainActor`

## Testing
- `swift --version`
- `swiftlint --fix --format --strict --no-cache` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f0d9bbe883209b33308ed30f8b8b