### PR TITLE
Add delete support for tags with ingredient check

### DIFF
--- a/Cookle/Resources/Localizable.xcstrings
+++ b/Cookle/Resources/Localizable.xcstrings
@@ -495,6 +495,9 @@
         }
       }
     },
+    "Cannot Delete" : {
+
+    },
     "Categories" : {
       "localizations" : {
         "en" : {
@@ -2891,6 +2894,9 @@
           }
         }
       }
+    },
+    "This item is used by existing recipes." : {
+
     },
     "Type" : {
       "localizations" : {

--- a/Cookle/Sources/Tag/Components/DeleteTagButton.swift
+++ b/Cookle/Sources/Tag/Components/DeleteTagButton.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct DeleteTagButton<T: Tag>: View {
+    @Environment(T.self) private var tag
+
+    @State private var isConfirmationPresented = false
+    @State private var isAlertPresented = false
+
+    private let action: (() -> Void)?
+
+    init(action: (() -> Void)? = nil) {
+        self.action = action
+    }
+
+    var body: some View {
+        Button(role: .destructive) {
+            if let action {
+                action()
+            } else if tag is Ingredient, tag.recipes.orEmpty.isNotEmpty {
+                isAlertPresented = true
+            } else {
+                isConfirmationPresented = true
+            }
+        } label: {
+            Label {
+                Text("Delete")
+            } icon: {
+                Image(systemName: "trash")
+            }
+        }
+        .alert(
+            Text("Cannot Delete"),
+            isPresented: $isAlertPresented
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("This item is used by existing recipes.")
+        }
+        .confirmationDialog(
+            Text("Delete \(tag.value)"),
+            isPresented: $isConfirmationPresented
+        ) {
+            Button("Delete", role: .destructive) {
+                tag.delete()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to delete this item? This action cannot be undone.")
+        }
+    }
+}
+
+#Preview {
+    CooklePreview { preview in
+        DeleteTagButton<Category>()
+            .environment(preview.categories[0])
+    }
+}

--- a/Cookle/Sources/Tag/Views/TagView.swift
+++ b/Cookle/Sources/Tag/Views/TagView.swift
@@ -39,6 +39,12 @@ struct TagView<T: Tag>: View {
             } header: {
                 Text("Updated At")
             }
+            Section {
+                EditTagButton<T>()
+                DeleteTagButton<T>()
+            } header: {
+                Spacer()
+            }
         }
         .navigationTitle(tag.value)
         .toolbar {


### PR DESCRIPTION
## Summary
- add `DeleteTagButton` component for removing tags
- allow deleting and editing tags from within `TagView`
- block ingredient deletion when recipes reference it

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_686b5b4997f88320b0decf8dc97c9f09