### PR TITLE
Refactor views to use Recipe model

### DIFF
--- a/Cookle/Sources/Common/Models/CookleImagePlayground.swift
+++ b/Cookle/Sources/Common/Models/CookleImagePlayground.swift
@@ -23,7 +23,7 @@ extension View {
     @ViewBuilder
     func cookleImagePlayground(
         isPresented: Binding<Bool>,
-        recipe: RecipeEntity?,
+        recipe: Recipe?,
         onCompletion: @escaping (Data) -> Void,
         onCancellation: (() -> Void)? = nil
     ) -> some View {

--- a/Cookle/Sources/Diary/Views/DiaryFormRecipeListView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryFormRecipeListView.swift
@@ -12,17 +12,17 @@ import SwiftUtilities
 struct DiaryFormRecipeListView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @BridgeQuery(.recipes(.all))
-    private var recipes: [RecipeEntity]
+    @Query(.recipes(.all))
+    private var recipes: [Recipe]
 
-    @Binding private var selection: Set<RecipeEntity>
+    @Binding private var selection: Set<Recipe>
 
-    @State private var temporarySelection = Set<RecipeEntity>()
+    @State private var temporarySelection = Set<Recipe>()
     @State private var searchText = ""
 
     private let type: DiaryObjectType
 
-    init(selection: Binding<Set<RecipeEntity>> = .constant([]), type: DiaryObjectType) {
+    init(selection: Binding<Set<Recipe>> = .constant([]), type: DiaryObjectType) {
         _selection = selection
         _temporarySelection = .init(initialValue: selection.wrappedValue)
         self.type = type

--- a/Cookle/Sources/Diary/Views/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryFormView.swift
@@ -15,9 +15,9 @@ struct DiaryFormView: View {
     @Environment(Diary.self) private var diary: Diary?
 
     @State private var date = Date.now
-    @State private var breakfasts = Set<RecipeEntity>()
-    @State private var lunches = Set<RecipeEntity>()
-    @State private var dinners = Set<RecipeEntity>()
+    @State private var breakfasts = Set<Recipe>()
+    @State private var lunches = Set<Recipe>()
+    @State private var dinners = Set<Recipe>()
     @State private var note = ""
 
     var body: some View {
@@ -127,16 +127,12 @@ struct DiaryFormView: View {
 }
 
 private extension DiaryFormView {
-    func recipes(from entities: Set<RecipeEntity>) -> [Recipe] {
-        entities.compactMap { entity -> Recipe? in
-            try? context.fetchFirst(.recipes(.idIs(.init(base64Encoded: entity.id))))
-        }
+    func recipes(from models: Set<Recipe>) -> [Recipe] {
+        Array(models)
     }
 
-    func recipeEntities(from models: [Recipe]) -> Set<RecipeEntity> {
-        Set(models.compactMap {
-            RecipeEntity($0)
-        })
+    func recipeEntities(from models: [Recipe]) -> Set<Recipe> {
+        Set(models)
     }
 }
 

--- a/Cookle/Sources/Diary/Views/DiaryNavigationView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryNavigationView.swift
@@ -12,7 +12,7 @@ struct DiaryNavigationView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var diary: Diary?
-    @State private var recipe: RecipeEntity?
+    @State private var recipe: Recipe?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Diary/Views/DiaryView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct DiaryView: View {
     @Environment(Diary.self) private var diary
 
-    @Binding private var recipe: RecipeEntity?
+    @Binding private var recipe: Recipe?
 
-    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
+    init(selection: Binding<Recipe?> = .constant(nil)) {
         _recipe = selection
     }
 
@@ -26,14 +26,7 @@ struct DiaryView: View {
                         }
                     )
                     .sorted()
-                    .compactMap(
-                        { object -> RecipeEntity? in
-                            guard let model = object.recipe else {
-                                return nil
-                            }
-                            return RecipeEntity(model)
-                        }
-                    ),
+                    .compactMap(\.recipe),
                    recipes.isNotEmpty {
                     Section {
                         ForEach(recipes) { recipe in

--- a/Cookle/Sources/Photo/Views/PhotoNavigationView.swift
+++ b/Cookle/Sources/Photo/Views/PhotoNavigationView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PhotoNavigationView: View {
     @State private var photo: Photo?
-    @State private var recipe: RecipeEntity?
+    @State private var recipe: Recipe?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Photo/Views/PhotoView.swift
+++ b/Cookle/Sources/Photo/Views/PhotoView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct PhotoView: View {
     @Environment(Photo.self) private var photo
 
-    @Binding private var recipe: RecipeEntity?
+    @Binding private var recipe: Recipe?
 
     @State private var isPhotoDetailPresented = false
 
-    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
+    init(selection: Binding<Recipe?> = .constant(nil)) {
         _recipe = selection
     }
 
@@ -36,7 +36,7 @@ struct PhotoView: View {
                 }
             }
             Section {
-                ForEach(photo.recipes.orEmpty.compactMap(RecipeEntity.init)) { recipe in
+                ForEach(photo.recipes.orEmpty) { recipe in
                     NavigationLink(value: recipe) {
                         RecipeLabel()
                             .labelStyle(.titleOnly)

--- a/Cookle/Sources/Recipe/Components/CreateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/CreateRecipeButton.swift
@@ -12,7 +12,7 @@ struct CreateRecipeButton: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.requestReview) private var requestReview
 
-    @State private var recipe: RecipeEntity?
+    @State private var recipe: Recipe?
     @State private var isConfirmationDialogPresented = false
     @State private var isImagePlaygroundPresented = false
 
@@ -74,7 +74,7 @@ struct CreateRecipeButton: View {
                 },
                 note: note
             )
-            recipe = RecipeEntity(model)
+            recipe = model
             if recipe?.photos.isEmpty == true,
                CookleImagePlayground.isSupported {
                 isConfirmationDialogPresented = true
@@ -120,9 +120,8 @@ struct CreateRecipeButton: View {
             isPresented: $isImagePlaygroundPresented,
             recipe: recipe
         ) { data in
-            if let recipe,
-               let model = try? recipe.model(context: context) {
-                model.update(
+            if let recipe {
+                recipe.update(
                     name: recipe.name,
                     photos: [
                         .create(
@@ -136,9 +135,9 @@ struct CreateRecipeButton: View {
                     ],
                     servingSize: recipe.servingSize,
                     cookingTime: recipe.cookingTime,
-                    ingredients: model.ingredientObjects ?? [],
+                    ingredients: recipe.ingredientObjects ?? [],
                     steps: recipe.steps,
-                    categories: model.categories ?? [],
+                    categories: recipe.categories ?? [],
                     note: recipe.note
                 )
             }

--- a/Cookle/Sources/Recipe/Components/DeleteRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/DeleteRecipeButton.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct DeleteRecipeButton: View {
-    @Environment(RecipeEntity.self) private var recipe
-    @Environment(\.modelContext) private var context
+    @Environment(Recipe.self) private var recipe
 
     @State private var isPresented = false
 
@@ -31,9 +30,7 @@ struct DeleteRecipeButton: View {
             isPresented: $isPresented
         ) {
             Button("Delete", role: .destructive) {
-                if let model = try? recipe.model(context: context) {
-                    model.delete()
-                }
+                recipe.delete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Cookle/Sources/Recipe/Components/DuplicateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/DuplicateRecipeButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DuplicateRecipeButton: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     @State private var isPresented = false
 

--- a/Cookle/Sources/Recipe/Components/EditRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/EditRecipeButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EditRecipeButton: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     @State private var isPresented = false
 

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeCategoriesSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeCategoriesSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeCategoriesSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
     @Environment(\.modelContext) private var context
 
     var body: some View {
@@ -29,7 +29,7 @@ struct RecipeCategoriesSection: View {
     CooklePreview { preview in
         List {
             RecipeCategoriesSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeCookingTimeSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeCookingTimeSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeCookingTimeSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
         Section {
@@ -24,7 +24,7 @@ struct RecipeCookingTimeSection: View {
     CooklePreview { preview in
         List {
             RecipeCookingTimeSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeCreatedAtSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeCreatedAtSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeCreatedAtSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
         Section {
@@ -23,7 +23,7 @@ struct RecipeCreatedAtSection: View {
     CooklePreview { preview in
         List {
             RecipeCreatedAtSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeDiariesSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeDiariesSection.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct RecipeDiariesSection: View {
-    @Environment(RecipeEntity.self) private var recipe
-    @Environment(\.modelContext) private var context
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
-        if let diaries = try? recipe.model(context: context)?.diaries,
+        if let diaries = recipe.diaries,
            diaries.isNotEmpty {
             Section {
                 ForEach(diaries.sorted {
@@ -31,7 +30,7 @@ struct RecipeDiariesSection: View {
     CooklePreview { preview in
         List {
             RecipeDiariesSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeIngredientsSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeIngredientsSection.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct RecipeIngredientsSection: View {
-    @Environment(RecipeEntity.self) private var recipe
-    @Environment(\.modelContext) private var context
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
-        if let objects = try? recipe.model(context: context)?.ingredientObjects,
+        if let objects = recipe.ingredientObjects,
            objects.isNotEmpty {
             Section {
                 ForEach(objects.sorted()) { object in
@@ -34,7 +33,7 @@ struct RecipeIngredientsSection: View {
     List {
         CooklePreview { preview in
             RecipeIngredientsSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeNoteSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeNoteSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeNoteSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
         Section {
@@ -24,7 +24,7 @@ struct RecipeNoteSection: View {
     CooklePreview { preview in
         List {
             RecipeNoteSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipePhotosSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipePhotosSection.swift
@@ -8,13 +8,12 @@
 import SwiftUI
 
 struct RecipePhotosSection: View {
-    @Environment(RecipeEntity.self) private var recipe
-    @Environment(\.modelContext) private var context
+    @Environment(Recipe.self) private var recipe
 
     @State private var selectedPhoto: Photo?
 
     var body: some View {
-        if let photoObjects = try? recipe.model(context: context)?.photoObjects,
+        if let photoObjects = recipe.photoObjects,
            photoObjects.isNotEmpty {
             Section {
                 ScrollView(.horizontal) {
@@ -54,7 +53,7 @@ struct RecipePhotosSection: View {
     CooklePreview { preview in
         List {
             RecipePhotosSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeServingSizeSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeServingSizeSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeServingSizeSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
         Section {
@@ -24,7 +24,7 @@ struct RecipeServingSizeSection: View {
     CooklePreview { preview in
         List {
             RecipeServingSizeSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeStepsSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeStepsSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeStepsSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
         Section {
@@ -31,7 +31,7 @@ struct RecipeStepsSection: View {
     CooklePreview { preview in
         List {
             RecipeStepsSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/Recipe/RecipeUpdatedAtSection.swift
+++ b/Cookle/Sources/Recipe/Components/Recipe/RecipeUpdatedAtSection.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeUpdatedAtSection: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     var body: some View {
         Section {
@@ -23,7 +23,7 @@ struct RecipeUpdatedAtSection: View {
     CooklePreview { preview in
         List {
             RecipeUpdatedAtSection()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotosSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotosSection.swift
@@ -9,7 +9,7 @@ import PhotosUI
 import SwiftUI
 
 struct RecipeFormPhotosSection: View {
-    @Environment(RecipeEntity.self) private var recipe: RecipeEntity?
+    @Environment(Recipe.self) private var recipe: Recipe?
     @Environment(\.editMode) private var editMode
 
     @Binding private var photos: [PhotoData]

--- a/Cookle/Sources/Recipe/Components/RecipeLabel.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeLabel.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct RecipeLabel: View {
-    @Environment(RecipeEntity.self) private var recipe
-    @Environment(\.modelContext) private var context
+    @Environment(Recipe.self) private var recipe
 
     @State private var isEditPresented = false
     @State private var isDuplicatePresented = false
@@ -13,13 +12,15 @@ struct RecipeLabel: View {
             VStack(alignment: .leading) {
                 Text(recipe.name)
                 Text(
-                    recipe.ingredients.map(\.ingredient).joined(separator: ", ")
+                    recipe.ingredientObjects?.sorted().compactMap { object in
+                        object.ingredient?.value
+                    }.joined(separator: ", ") ?? ""
                 )
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 Text(
-                    recipe.categories.joined(separator: ", ")
+                    recipe.categories?.map(\.value).joined(separator: ", ") ?? ""
                 )
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -55,9 +56,7 @@ struct RecipeLabel: View {
             isPresented: $isDeletePresented
         ) {
             Button("Delete", role: .destructive) {
-                if let model = try? recipe.model(context: context) {
-                    model.delete()
-                }
+                recipe.delete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Cookle/Sources/Recipe/Components/UpdateRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/UpdateRecipeButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct UpdateRecipeButton: View {
-    @Environment(RecipeEntity.self) private var recipe: RecipeEntity
+    @Environment(Recipe.self) private var recipe: Recipe
     @Environment(\.modelContext) private var context
     @Environment(\.dismiss) private var dismiss
     @Environment(\.requestReview) private var requestReview
@@ -46,10 +46,7 @@ struct UpdateRecipeButton: View {
 
     var body: some View {
         Button {
-            guard let model = try? recipe.model(context: context) else {
-                return
-            }
-            model.update(
+            recipe.update(
                 name: name,
                 photos: zip(photos.indices, photos).map { index, element in
                     .create(context: context, photoData: element, order: index + 1)

--- a/Cookle/Sources/Recipe/Views/RecipeFormView.swift
+++ b/Cookle/Sources/Recipe/Views/RecipeFormView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct RecipeFormView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @Environment(RecipeEntity.self) private var recipe: RecipeEntity?
+    @Environment(Recipe.self) private var recipe: Recipe?
     @Environment(\.modelContext) private var context
 
     @AppStorage(.isDebugOn) private var isDebugOn
@@ -151,8 +151,7 @@ struct RecipeFormView: View {
             Text("Are you really going to use DebugMode?")
         }
         .task {
-            guard let entity = recipe,
-                  let model = try? entity.model(context: context) else {
+            guard let model = recipe else {
                 return
             }
             name = model.name

--- a/Cookle/Sources/Recipe/Views/RecipeListView.swift
+++ b/Cookle/Sources/Recipe/Views/RecipeListView.swift
@@ -12,13 +12,13 @@ import SwiftUtilities
 struct RecipeListView: View {
     @Environment(\.isPresented) private var isPresented
 
-    @BridgeQuery private var recipes: [RecipeEntity]
+    @Query private var recipes: [Recipe]
 
-    @Binding private var recipe: RecipeEntity?
+    @Binding private var recipe: Recipe?
 
     @State private var searchText = ""
 
-    init(selection: Binding<RecipeEntity?> = .constant(nil), descriptor: FetchDescriptor<Recipe> = .recipes(.all)) {
+    init(selection: Binding<Recipe?> = .constant(nil), descriptor: FetchDescriptor<Recipe> = .recipes(.all)) {
         _recipe = selection
         _recipes = .init(descriptor)
     }

--- a/Cookle/Sources/Recipe/Views/RecipeNavigationView.swift
+++ b/Cookle/Sources/Recipe/Views/RecipeNavigationView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct RecipeNavigationView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    @State private var recipe: RecipeEntity?
+    @State private var recipe: Recipe?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Recipe/Views/RecipeView.swift
+++ b/Cookle/Sources/Recipe/Views/RecipeView.swift
@@ -9,7 +9,7 @@ import SwiftData
 import SwiftUI
 
 struct RecipeView: View {
-    @Environment(RecipeEntity.self) private var recipe
+    @Environment(Recipe.self) private var recipe
 
     @AppStorage(.lastOpenedRecipeID) private var lastOpenedRecipeID
     @AppStorage(.isSubscribeOn) private var isSubscribeOn
@@ -54,7 +54,7 @@ struct RecipeView: View {
     CooklePreview { preview in
         NavigationStack {
             RecipeView()
-                .environment(RecipeEntity(preview.recipes[0])!)
+                .environment(preview.recipes[0])
         }
     }
 }

--- a/Cookle/Sources/Search/Views/SearchNavigationView.swift
+++ b/Cookle/Sources/Search/Views/SearchNavigationView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SearchNavigationView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    @State private var recipe: RecipeEntity?
+    @State private var recipe: Recipe?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Search/Views/SearchView.swift
+++ b/Cookle/Sources/Search/Views/SearchView.swift
@@ -13,13 +13,13 @@ struct SearchView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.isPresented) private var isPresented
 
-    @Binding private var recipe: RecipeEntity?
+    @Binding private var recipe: Recipe?
 
-    @State private var recipes = [RecipeEntity]()
+    @State private var recipes = [Recipe]()
     @State private var searchText = ""
     @State private var isFocused = false
 
-    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
+    init(selection: Binding<Recipe?> = .constant(nil)) {
         _recipe = selection
     }
 
@@ -85,7 +85,7 @@ struct SearchView: View {
                 models += ingredients.flatMap(\.recipes.orEmpty)
                 models += categories.flatMap(\.recipes.orEmpty)
                 models = Array(Set(models))
-                recipes = models.compactMap(RecipeEntity.init)
+                recipes = models
             } catch {}
         }
     }

--- a/Cookle/Sources/Tag/Views/TagNavigationView.swift
+++ b/Cookle/Sources/Tag/Views/TagNavigationView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TagNavigationView<T: Tag>: View {
     @State private var tag: T?
-    @State private var recipe: RecipeEntity?
+    @State private var recipe: Recipe?
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {

--- a/Cookle/Sources/Tag/Views/TagView.swift
+++ b/Cookle/Sources/Tag/Views/TagView.swift
@@ -10,16 +10,16 @@ import SwiftUI
 struct TagView<T: Tag>: View {
     @Environment(T.self) private var tag
 
-    @Binding private var recipe: RecipeEntity?
+    @Binding private var recipe: Recipe?
 
-    init(selection: Binding<RecipeEntity?> = .constant(nil)) {
+    init(selection: Binding<Recipe?> = .constant(nil)) {
         _recipe = selection
     }
 
     var body: some View {
         List(selection: $recipe) {
             Section {
-                ForEach(tag.recipes.orEmpty.compactMap(RecipeEntity.init)) { recipe in
+                ForEach(tag.recipes.orEmpty) { recipe in
                     NavigationLink(value: recipe) {
                         RecipeLabel()
                             .labelStyle(.titleAndLargeIcon)


### PR DESCRIPTION
## Summary
- replace RecipeEntity with Recipe in views and components
- update environment keys and queries for Recipe
- keep RecipeEntity only for intents

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d005d2f883208e24620708e73e93