### PR TITLE
Refactor context handling to intents

### DIFF
--- a/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
+++ b/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
@@ -1,0 +1,28 @@
+import AppIntents
+import SwiftData
+
+struct CreateDiaryIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, date: Date, breakfasts: [Recipe], lunches: [Recipe], dinners: [Recipe], note: String)
+    typealias Output = Diary
+
+    static func perform(_ input: Input) -> Output {
+        let (context, date, breakfasts, lunches, dinners, note) = input
+        let objects = zip(breakfasts.indices, breakfasts).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .breakfast, order: index + 1)
+        } + zip(lunches.indices, lunches).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .lunch, order: index + 1)
+        } + zip(dinners.indices, dinners).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .dinner, order: index + 1)
+        }
+        return Diary.create(
+            context: context,
+            date: date,
+            objects: objects,
+            note: note
+        )
+    }
+
+    func perform() throws -> some IntentResult {
+        .result()
+    }
+}

--- a/Cookle/Sources/Diary/Intents/UpdateDiaryIntent.swift
+++ b/Cookle/Sources/Diary/Intents/UpdateDiaryIntent.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import SwiftData
+
+struct UpdateDiaryIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, diary: Diary, date: Date, breakfasts: [Recipe], lunches: [Recipe], dinners: [Recipe], note: String)
+    typealias Output = Void
+
+    static func perform(_ input: Input) {
+        let (context, diary, date, breakfasts, lunches, dinners, note) = input
+        let objects = zip(breakfasts.indices, breakfasts).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .breakfast, order: index + 1)
+        } + zip(lunches.indices, lunches).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .lunch, order: index + 1)
+        } + zip(dinners.indices, dinners).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .dinner, order: index + 1)
+        }
+        diary.update(
+            date: date,
+            objects: objects,
+            note: note
+        )
+    }
+
+    func perform() throws -> some IntentResult {
+        .result()
+    }
+}

--- a/Cookle/Sources/Diary/Views/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryFormView.swift
@@ -77,29 +77,27 @@ struct DiaryFormView: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button {
                     if let diary {
-                        diary.update(
-                            date: date,
-                            objects: zip(recipes(from: breakfasts).indices, recipes(from: breakfasts)).map { index, element in
-                                .create(context: context, recipe: element, type: .breakfast, order: index + 1)
-                            } + zip(recipes(from: lunches).indices, recipes(from: lunches)).map { index, element in
-                                .create(context: context, recipe: element, type: .lunch, order: index + 1)
-                            } + zip(recipes(from: dinners).indices, recipes(from: dinners)).map { index, element in
-                                .create(context: context, recipe: element, type: .dinner, order: index + 1)
-                            },
-                            note: note
+                        UpdateDiaryIntent.perform(
+                            (
+                                context: context,
+                                diary: diary,
+                                date: date,
+                                breakfasts: recipes(from: breakfasts),
+                                lunches: recipes(from: lunches),
+                                dinners: recipes(from: dinners),
+                                note: note
+                            )
                         )
                     } else {
-                        _ = Diary.create(
-                            context: context,
-                            date: date,
-                            objects: zip(recipes(from: breakfasts).indices, recipes(from: breakfasts)).map { index, element in
-                                .create(context: context, recipe: element, type: .breakfast, order: index + 1)
-                            } + zip(recipes(from: lunches).indices, recipes(from: lunches)).map { index, element in
-                                .create(context: context, recipe: element, type: .lunch, order: index + 1)
-                            } + zip(recipes(from: dinners).indices, recipes(from: dinners)).map { index, element in
-                                .create(context: context, recipe: element, type: .dinner, order: index + 1)
-                            },
-                            note: note
+                        _ = CreateDiaryIntent.perform(
+                            (
+                                context: context,
+                                date: date,
+                                breakfasts: recipes(from: breakfasts),
+                                lunches: recipes(from: lunches),
+                                dinners: recipes(from: dinners),
+                                note: note
+                            )
                         )
                     }
                     dismiss()

--- a/Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import SwiftData
+
+struct SearchRecipesIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, text: String)
+    typealias Output = [Recipe]
+
+    static func perform(_ input: Input) throws -> Output {
+        let (context, text) = input
+        var recipes = try context.fetch(
+            .recipes(.nameContains(text))
+        )
+        let ingredients = try context.fetch(
+            text.count < 3 ? .ingredients(.valueIs(text)) : .ingredients(.valueContains(text))
+        )
+        let categories = try context.fetch(
+            text.count < 3 ? .categories(.valueIs(text)) : .categories(.valueContains(text))
+        )
+        recipes += ingredients.flatMap(\.recipes.orEmpty)
+        recipes += categories.flatMap(\.recipes.orEmpty)
+        return Array(Set(recipes))
+    }
+
+    func perform() throws -> some IntentResult {
+        .result()
+    }
+}

--- a/Cookle/Sources/Search/Views/SearchView.swift
+++ b/Cookle/Sources/Search/Views/SearchView.swift
@@ -68,23 +68,12 @@ struct SearchView: View {
         }
         .onChange(of: searchText) {
             do {
-                var models = try context.fetch(
-                    .recipes(.nameContains(searchText))
+                recipes = try SearchRecipesIntent.perform(
+                    (
+                        context: context,
+                        text: searchText
+                    )
                 )
-                let ingredients = try context.fetch(
-                    searchText.count < 3
-                        ? .ingredients(.valueIs(searchText))
-                        : .ingredients(.valueContains(searchText))
-                )
-                let categories = try context.fetch(
-                    searchText.count < 3
-                        ? .categories(.valueIs(searchText))
-                        : .categories(.valueContains(searchText))
-                )
-                models += ingredients.flatMap(\.recipes.orEmpty)
-                models += categories.flatMap(\.recipes.orEmpty)
-                models = Array(Set(models))
-                recipes = models
             } catch {}
         }
     }

--- a/CookleTests/CookleTests.swift
+++ b/CookleTests/CookleTests.swift
@@ -6,9 +6,79 @@
 //
 
 import Testing
+import SwiftData
+
+@testable import Cookle
 
 struct CookleTests {
-    @Test func example() throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func recipeSearch() throws {
+        let container = try ModelContainer(
+            for: Recipe.self,
+            configurations: .init(isStoredInMemoryOnly: true)
+        )
+        let context = container.mainContext
+        _ = Recipe.create(
+            context: context,
+            name: "Pancakes",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+        _ = Recipe.create(
+            context: context,
+            name: "Spaghetti",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+
+        let result = try SearchRecipesIntent.perform(
+            (
+                context: context,
+                text: "Panc"
+            )
+        )
+        #expect(result.count == 1)
+        #expect(result.first?.name == "Pancakes")
+    }
+
+    @Test func diaryCreate() throws {
+        let container = try ModelContainer(
+            for: Recipe.self, Diary.self, DiaryObject.self,
+            configurations: .init(isStoredInMemoryOnly: true)
+        )
+        let context = container.mainContext
+        let pancake = Recipe.create(
+            context: context,
+            name: "Pancakes",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+        _ = CreateDiaryIntent.perform(
+            (
+                context: context,
+                date: .now,
+                breakfasts: [pancake],
+                lunches: [],
+                dinners: [],
+                note: "Note"
+            )
+        )
+
+        let diaries = try context.fetch(.diaries(.all))
+        #expect(diaries.first?.objects?.first?.recipe === pancake)
     }
 }


### PR DESCRIPTION
## Summary
- replace helper enums with AppIntent structures
- update DiaryFormView and SearchView to use new intents
- revise unit tests for new intent-based APIs

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `xcodebuild -list -project Cookle.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871148e48c4832090f39470afc5f669