### PR TITLE
Add tests for all AppIntents

### DIFF
--- a/CookleTests/InferRecipeIntentTests.swift
+++ b/CookleTests/InferRecipeIntentTests.swift
@@ -8,7 +8,6 @@
 @testable import Cookle
 import Testing
 
-@available(iOS 26.0, *)
 struct InferRecipeIntentTests {
     @Test func perform() async throws {
         let result = try await InferRecipeIntent.perform("Pancake recipe")

--- a/CookleTests/InferRecipeIntentTests.swift
+++ b/CookleTests/InferRecipeIntentTests.swift
@@ -1,0 +1,17 @@
+//
+//  InferRecipeIntentTests.swift
+//  Cookle
+//
+//  Created by Codex on 2025/07/12.
+//
+
+@testable import Cookle
+import Testing
+
+@available(iOS 26.0, *)
+struct InferRecipeIntentTests {
+    @Test func perform() async throws {
+        let result = try await InferRecipeIntent.perform("Pancake recipe")
+        #expect(!result.name.isEmpty)
+    }
+}

--- a/CookleTests/OpenCookleIntentTests.swift
+++ b/CookleTests/OpenCookleIntentTests.swift
@@ -1,0 +1,15 @@
+//
+//  OpenCookleIntentTests.swift
+//  Cookle
+//
+//  Created by Codex on 2025/07/12.
+//
+
+@testable import Cookle
+import Testing
+
+struct OpenCookleIntentTests {
+    @Test func perform() throws {
+        try OpenCookleIntent.perform(())
+    }
+}

--- a/CookleTests/ShowLastOpenedRecipeIntentTests.swift
+++ b/CookleTests/ShowLastOpenedRecipeIntentTests.swift
@@ -1,0 +1,34 @@
+//
+//  ShowLastOpenedRecipeIntentTests.swift
+//  Cookle
+//
+//  Created by Codex on 2025/07/12.
+//
+
+@testable import Cookle
+import Testing
+import SwiftData
+import SwiftUI
+
+struct ShowLastOpenedRecipeIntentTests {
+    let context = testContext
+
+    @Test func perform() throws {
+        let recipe = Recipe.create(
+            context: context,
+            name: "Pancakes",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+        let encoded = try recipe.id.base64Encoded()
+        AppStorage(.lastOpenedRecipeID).wrappedValue = encoded
+
+        let result = try ShowLastOpenedRecipeIntent.perform(context)
+        #expect(result === recipe)
+    }
+}

--- a/CookleTests/ShowRandomRecipeIntentTests.swift
+++ b/CookleTests/ShowRandomRecipeIntentTests.swift
@@ -1,0 +1,43 @@
+//
+//  ShowRandomRecipeIntentTests.swift
+//  Cookle
+//
+//  Created by Codex on 2025/07/12.
+//
+
+@testable import Cookle
+import Testing
+import SwiftData
+
+struct ShowRandomRecipeIntentTests {
+    let context = testContext
+
+    @Test func perform() throws {
+        let pancake = Recipe.create(
+            context: context,
+            name: "Pancakes",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+        _ = Recipe.create(
+            context: context,
+            name: "Spaghetti",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+
+        let result = try ShowRandomRecipeIntent.perform(context)
+        #expect(result != nil)
+        #expect(result === pancake || result?.name == "Spaghetti")
+    }
+}

--- a/CookleTests/ShowSearchResultIntentTests.swift
+++ b/CookleTests/ShowSearchResultIntentTests.swift
@@ -1,0 +1,51 @@
+//
+//  ShowSearchResultIntentTests.swift
+//  Cookle
+//
+//  Created by Codex on 2025/07/12.
+//
+
+@testable import Cookle
+import Testing
+import SwiftData
+
+struct ShowSearchResultIntentTests {
+    let context = testContext
+
+    @Test func perform() throws {
+        _ = Recipe.create(
+            context: context,
+            name: "Pancakes",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [
+                .create(context: context, ingredient: "Egg", amount: "2", order: 1)
+            ],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+        let category = Category.create(context: context, value: "Breakfast")
+        _ = Recipe.create(
+            context: context,
+            name: "Toast",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 5,
+            ingredients: [],
+            steps: [],
+            categories: [category],
+            note: ""
+        )
+
+        let result = try ShowSearchResultIntent.perform(
+            (
+                context: context,
+                text: "Egg"
+            )
+        )
+        #expect(result.count == 1)
+        #expect(result.first?.name == "Pancakes")
+    }
+}

--- a/CookleTests/UpdateDiaryIntentTests.swift
+++ b/CookleTests/UpdateDiaryIntentTests.swift
@@ -1,0 +1,49 @@
+//
+//  UpdateDiaryIntentTests.swift
+//  Cookle
+//
+//  Created by Codex on 2025/07/12.
+//
+
+@testable import Cookle
+import Foundation
+import SwiftData
+import Testing
+
+struct UpdateDiaryIntentTests {
+    let context = testContext
+
+    @Test func perform() throws {
+        let pancake = Recipe.create(
+            context: context,
+            name: "Pancakes",
+            photos: [],
+            servingSize: 1,
+            cookingTime: 10,
+            ingredients: [],
+            steps: [],
+            categories: [],
+            note: ""
+        )
+        let diary = Diary.create(
+            context: context,
+            date: .now,
+            objects: [],
+            note: ""
+        )
+        UpdateDiaryIntent.perform(
+            (
+                context: context,
+                diary: diary,
+                date: .now,
+                breakfasts: [pancake],
+                lunches: [],
+                dinners: [],
+                note: "Updated"
+            )
+        )
+
+        #expect(diary.note == "Updated")
+        #expect(diary.objects?.first?.recipe === pancake)
+    }
+}


### PR DESCRIPTION
## Summary
- add UpdateDiaryIntentTests to verify updating diaries
- add ShowSearchResultIntentTests covering search results
- add OpenCookleIntentTests for basic invocation
- add ShowRandomRecipeIntentTests checking random recipe retrieval
- add ShowLastOpenedRecipeIntentTests ensuring retrieval by storage key
- add InferRecipeIntentTests with async call

## Testing
- `pre-commit run --files CookleTests/UpdateDiaryIntentTests.swift CookleTests/ShowSearchResultIntentTests.swift CookleTests/OpenCookleIntentTests.swift CookleTests/ShowRandomRecipeIntentTests.swift CookleTests/ShowLastOpenedRecipeIntentTests.swift CookleTests/InferRecipeIntentTests.swift` *(fails: error 403 fetching SwiftLint)*

------
https://chatgpt.com/codex/tasks/task_e_6871ab1df1608320b051b50dd06c9c71