### PR TITLE
Annotate intents with MainActor for main context

### DIFF
--- a/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
+++ b/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
@@ -46,6 +46,7 @@ struct CreateDiaryIntent: AppIntent, IntentPerformer {
         )
     }
 
+    @MainActor
     func perform() throws -> some IntentResult {
         let context = modelContainer.mainContext
         _ = Self.perform(

--- a/Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift
@@ -37,6 +37,7 @@ struct SearchRecipesIntent: AppIntent, IntentPerformer {
         return Array(Set(recipes))
     }
 
+    @MainActor
     func perform() throws -> some ReturnsValue<[RecipeEntity]> {
         .result(
             value: try Self.perform(

--- a/Cookle/Sources/Recipe/Intents/ShowLastOpenedRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/ShowLastOpenedRecipeIntent.swift
@@ -19,6 +19,7 @@ struct ShowLastOpenedRecipeIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
+    @MainActor
     static func perform(_ input: Input) throws -> Output {
         let context = input
         guard let lastOpenedRecipeID = AppStorage(.lastOpenedRecipeID).wrappedValue else {
@@ -28,6 +29,7 @@ struct ShowLastOpenedRecipeIntent: AppIntent, IntentPerformer {
         return try context.fetchFirst(.recipes(.idIs(id)))
     }
 
+    @MainActor
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
         guard let recipe = try Self.perform(modelContainer.mainContext) else {
             return .result(dialog: "Not Found")

--- a/Cookle/Sources/Recipe/Intents/ShowRandomRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/ShowRandomRecipeIntent.swift
@@ -24,6 +24,7 @@ struct ShowRandomRecipeIntent: AppIntent, IntentPerformer {
         return try context.fetchRandom(.recipes(.all))
     }
 
+    @MainActor
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
         guard let recipe = try Self.perform(modelContainer.mainContext) else {
             return .result(dialog: "Not Found")

--- a/Cookle/Sources/Recipe/Models/RecipeEntityQuery.swift
+++ b/Cookle/Sources/Recipe/Models/RecipeEntityQuery.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct RecipeEntityQuery: EntityStringQuery {
     @Dependency private var modelContainer: ModelContainer
 
+    @MainActor
     func entities(for identifiers: [RecipeEntity.ID]) throws -> [RecipeEntity] {
         try identifiers.compactMap { id in
             let persistentIdentifier = try PersistentIdentifier(base64Encoded: id)
@@ -16,12 +17,14 @@ struct RecipeEntityQuery: EntityStringQuery {
         }
     }
 
+    @MainActor
     func entities(matching string: String) throws -> [RecipeEntity] {
         try modelContainer.mainContext.fetch(
             .recipes(.nameContains(string))
         ).compactMap(RecipeEntity.init)
     }
 
+    @MainActor
     func suggestedEntities() throws -> [RecipeEntity] {
         try modelContainer.mainContext.fetch(
             .recipes(.all)

--- a/Cookle/Sources/Search/Intents/ShowSearchResultIntent.swift
+++ b/Cookle/Sources/Search/Intents/ShowSearchResultIntent.swift
@@ -42,6 +42,7 @@ struct ShowSearchResultIntent: AppIntent, IntentPerformer {
         return recipes
     }
 
+    @MainActor
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
         _ = try Self.perform((context: modelContainer.mainContext, text: searchText))
         return .result(dialog: "Result") {


### PR DESCRIPTION
## Summary
- ensure intent perform methods run on the main actor when using `modelContainer.mainContext`
- mark recipe entity query methods as `@MainActor`
- adjust diary creation intent to access `mainContext` on main actor

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `apt-get install -y swiftlint` *(fails: Unable to locate package swiftlint)*

------
https://chatgpt.com/codex/tasks/task_e_689604fd56908320b1ba71b3dd0ab434