### PR TITLE
feat: add logging for debugging

### DIFF
--- a/Cookle/ContentView.swift
+++ b/Cookle/ContentView.swift
@@ -12,6 +12,9 @@ struct ContentView: View {
 
     var body: some View {
         MainView()
+            .onAppear {
+                Logger(#file).info("ContentView appeared")
+            }
     }
 }
 

--- a/Cookle/Sources/Common/Logger.swift
+++ b/Cookle/Sources/Common/Logger.swift
@@ -1,0 +1,12 @@
+import Foundation
+@_exported import OSLog
+
+extension Logger {
+    init(_ file: String) {
+        self.init(
+            subsystem: Bundle.main.bundleIdentifier!,
+            category: file
+        )
+    }
+}
+

--- a/Cookle/Sources/Common/Models/SpeechRecognizer.swift
+++ b/Cookle/Sources/Common/Models/SpeechRecognizer.swift
@@ -10,10 +10,12 @@ final class SpeechRecognizer: NSObject, ObservableObject {
     private var task: SFSpeechRecognitionTask?
 
     func start() throws {
+        Logger(#file).info("Start recording")
         let recognizer = SFSpeechRecognizer()
         audioEngine = .init()
         request = .init()
         guard let audioEngine, let request else {
+            Logger(#file).error("Failed to initialize audio engine or request")
             return
         }
 
@@ -27,7 +29,11 @@ final class SpeechRecognizer: NSObject, ObservableObject {
             request.append(buffer)
         }
 
-        task = recognizer?.recognitionTask(with: request) { result, _ in
+        task = recognizer?.recognitionTask(with: request) { result, error in
+            if let error {
+                Logger(#file).error("Speech recognition failed: \(error.localizedDescription)")
+                return
+            }
             guard let result else {
                 return
             }
@@ -36,14 +42,17 @@ final class SpeechRecognizer: NSObject, ObservableObject {
 
         audioEngine.prepare()
         try audioEngine.start()
+        Logger(#file).notice("Recording started")
     }
 
     func stop() {
+        Logger(#file).info("Stop recording")
         audioEngine?.stop()
         request?.endAudio()
         task?.cancel()
         audioEngine = nil
         request = nil
         task = nil
+        Logger(#file).notice("Recording stopped")
     }
 }

--- a/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
+++ b/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
@@ -48,17 +48,31 @@ struct CreateDiaryIntent: AppIntent, IntentPerformer {
     }
 
     func perform() throws -> some IntentResult {
+        Logger(#file).info("Running CreateDiaryIntent")
         let context = modelContainer.mainContext
+        let breakfastModels = breakfasts.compactMap { try? $0.model(context: context) }
+        if breakfastModels.count != breakfasts.count {
+            Logger(#file).error("Failed to convert some breakfasts")
+        }
+        let lunchModels = lunches.compactMap { try? $0.model(context: context) }
+        if lunchModels.count != lunches.count {
+            Logger(#file).error("Failed to convert some lunches")
+        }
+        let dinnerModels = dinners.compactMap { try? $0.model(context: context) }
+        if dinnerModels.count != dinners.count {
+            Logger(#file).error("Failed to convert some dinners")
+        }
         _ = Self.perform(
             (
                 context: context,
                 date: date,
-                breakfasts: breakfasts.compactMap { try? $0.model(context: context) },
-                lunches: lunches.compactMap { try? $0.model(context: context) },
-                dinners: dinners.compactMap { try? $0.model(context: context) },
+                breakfasts: breakfastModels,
+                lunches: lunchModels,
+                dinners: dinnerModels,
                 note: note
             )
         )
+        Logger(#file).notice("CreateDiaryIntent finished successfully")
         return .result()
     }
 }

--- a/Cookle/Sources/Recipe/Components/AddRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/AddRecipeButton.swift
@@ -18,6 +18,7 @@ struct AddRecipeButton: View {
 
     var body: some View {
         Button {
+            Logger(#file).info("AddRecipeButton tapped")
             if let action {
                 action()
             } else {


### PR DESCRIPTION
## Summary
- add Logger extension wrapping OSLog
- log view appearance and button taps
- track intent execution and speech recognition lifecycle
- re-export OSLog to remove per-file imports

## Testing
- `pre-commit run --files Cookle/ContentView.swift Cookle/Sources/Common/Logger.swift Cookle/Sources/Common/Models/SpeechRecognizer.swift Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift Cookle/Sources/Recipe/Components/AddRecipeButton.swift` *(fails: CalledProcessError: HTTP 403 fetching SwiftLint)*

------
https://chatgpt.com/codex/tasks/task_e_689677992fc083208ade0cdb8cb1c66a