### PR TITLE
Handle speech recognition errors and avoid crash

### DIFF
--- a/Cookle/Sources/Common/Models/SpeechRecognizer.swift
+++ b/Cookle/Sources/Common/Models/SpeechRecognizer.swift
@@ -4,52 +4,91 @@ import SwiftUI
 
 final class SpeechRecognizer: NSObject, ObservableObject {
     @Published private(set) var transcript = ""
+    @Published private(set) var errorMessage: String?
 
     private var audioEngine: AVAudioEngine?
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
 
+    enum SpeechRecognizerError: LocalizedError {
+        case recognizerUnavailable
+        case authorizationDenied
+        case initializationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .recognizerUnavailable:
+                return "Speech recognizer is not available."
+            case .authorizationDenied:
+                return "Speech recognition permission was denied."
+            case .initializationFailed:
+                return "Failed to initialize audio engine or recognition request."
+            }
+        }
+    }
+
     func start() throws {
         Logger(#file).info("Start recording")
-        let recognizer = SFSpeechRecognizer()
+
+        guard SFSpeechRecognizer.authorizationStatus() == .authorized else {
+            Logger(#file).error("Speech recognition not authorized")
+            throw SpeechRecognizerError.authorizationDenied
+        }
+
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            Logger(#file).error("Speech recognizer is not available")
+            throw SpeechRecognizerError.recognizerUnavailable
+        }
+
         audioEngine = .init()
-        request = .init()
-        guard let audioEngine, let request else {
+        let recognitionRequest: SFSpeechAudioBufferRecognitionRequest = .init()
+        request = recognitionRequest
+        guard let audioEngine else {
             Logger(#file).error("Failed to initialize audio engine or request")
-            return
+            throw SpeechRecognizerError.initializationFailed
         }
 
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
-        try session.setActive(true, options: .notifyOthersOnDeactivation)
+        do {
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            Logger(#file).error("Failed to configure audio session: \(error.localizedDescription)")
+            throw error
+        }
 
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: .zero)
-        inputNode.installTap(onBus: .zero, bufferSize: 1_024, format: format) { [weak self] buffer, _ in
-            let queueLabel = String(validatingUTF8: __dispatch_queue_get_label(nil)) ?? "unknown"
-            Logger(#file).debug(
-                "Appending buffer on queue: \(queueLabel), isMainThread: \(Thread.isMainThread)"
-            )
-            self?.request?.append(buffer)
+        inputNode.installTap(onBus: .zero, bufferSize: 1_024, format: format) { buffer, _ in
+            recognitionRequest.append(buffer)
         }
 
-        task = recognizer?.recognitionTask(with: request) { result, error in
+        task = recognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
             if let error {
                 Logger(#file).error("Speech recognition failed: \(error.localizedDescription)")
+                self?.errorMessage = error.localizedDescription
                 return
             }
             guard let result else {
                 Logger(#file).error("Speech recognition returned nil result")
+                self?.errorMessage = SpeechRecognizerError.initializationFailed.localizedDescription
                 return
             }
             Logger(#file).debug(
                 "Transcription: \(result.bestTranscription.formattedString), isFinal: \(result.isFinal)"
             )
-            self.transcript = result.bestTranscription.formattedString
+            DispatchQueue.main.async {
+                self?.transcript = result.bestTranscription.formattedString
+            }
         }
 
         audioEngine.prepare()
-        try audioEngine.start()
+        do {
+            try audioEngine.start()
+        } catch {
+            Logger(#file).error("Failed to start audio engine: \(error.localizedDescription)")
+            throw error
+        }
         Logger(#file).notice("Recording started")
     }
 

--- a/Cookle/Sources/Recipe/Views/InferRecipeFormView.swift
+++ b/Cookle/Sources/Recipe/Views/InferRecipeFormView.swift
@@ -100,13 +100,16 @@ struct InferRecipeFormView: View {
                     .disabled(isLoading)
                 }
                 ToolbarItemGroup(placement: .bottomBar) {
-                    // FIXME: Pressing this button is currently known to cause a crash. Investigate and fix the root cause.
                     Button {
                         if isRecording {
                             speechRecognizer.stop()
                             text += (text.isEmpty ? "" : "\n") + speechRecognizer.transcript
                         } else {
-                            try? speechRecognizer.start()
+                            do {
+                                try speechRecognizer.start()
+                            } catch {
+                                errorMessage = error.localizedDescription
+                            }
                         }
                         isRecording.toggle()
                     } label: {
@@ -157,7 +160,7 @@ struct InferRecipeFormView: View {
                     self.photoPickerItem = nil
                 }
             }
-            .onChange(of: cameraPickerItem) {
+              .onChange(of: cameraPickerItem) {
                 guard let cameraPickerItem else {
                     return
                 }
@@ -169,6 +172,12 @@ struct InferRecipeFormView: View {
                     }
                     self.cameraPickerItem = nil
                 }
+            }
+            .onChange(of: speechRecognizer.errorMessage) { _, newValue in
+                guard let newValue else {
+                    return
+                }
+                errorMessage = newValue
             }
             .onChange(of: speechRecognizer.transcript) { _, newValue in
                 guard !isRecording else {


### PR DESCRIPTION
## Summary
- prevent speech recognizer from running without authorization or availability
- surface speech recognition errors to the UI and log them
- remove crash-prone self capture in audio buffer tap

## Testing
- `pre-commit run --files Cookle/Sources/Common/Models/SpeechRecognizer.swift Cookle/Sources/Recipe/Views/InferRecipeFormView.swift` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `swiftlint --fix --format --strict Cookle/Sources/Common/Models/SpeechRecognizer.swift Cookle/Sources/Recipe/Views/InferRecipeFormView.swift` *(failed: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_689687cf539c8320b051f729f76fe3b4