### PR TITLE
refactor: delegate AppIntent logic to feature services

### DIFF
--- a/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
+++ b/Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift
@@ -31,19 +31,13 @@ struct CreateDiaryIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) -> Output {
-        let (context, date, breakfasts, lunches, dinners, note) = input
-        let objects = zip(breakfasts.indices, breakfasts).map { index, recipe in
-            DiaryObject.create(context: context, recipe: recipe, type: .breakfast, order: index + 1)
-        } + zip(lunches.indices, lunches).map { index, recipe in
-            DiaryObject.create(context: context, recipe: recipe, type: .lunch, order: index + 1)
-        } + zip(dinners.indices, dinners).map { index, recipe in
-            DiaryObject.create(context: context, recipe: recipe, type: .dinner, order: index + 1)
-        }
-        return Diary.create(
-            context: context,
-            date: date,
-            objects: objects,
-            note: note
+        DiaryService.create(
+            context: input.context,
+            date: input.date,
+            breakfasts: input.breakfasts,
+            lunches: input.lunches,
+            dinners: input.dinners,
+            note: input.note
         )
     }
 

--- a/Cookle/Sources/Diary/Intents/UpdateDiaryIntent.swift
+++ b/Cookle/Sources/Diary/Intents/UpdateDiaryIntent.swift
@@ -35,18 +35,14 @@ struct UpdateDiaryIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) {
-        let (context, diary, date, breakfasts, lunches, dinners, note) = input
-        let objects = zip(breakfasts.indices, breakfasts).map { index, recipe in
-            DiaryObject.create(context: context, recipe: recipe, type: .breakfast, order: index + 1)
-        } + zip(lunches.indices, lunches).map { index, recipe in
-            DiaryObject.create(context: context, recipe: recipe, type: .lunch, order: index + 1)
-        } + zip(dinners.indices, dinners).map { index, recipe in
-            DiaryObject.create(context: context, recipe: recipe, type: .dinner, order: index + 1)
-        }
-        diary.update(
-            date: date,
-            objects: objects,
-            note: note
+        DiaryService.update(
+            context: input.context,
+            diary: input.diary,
+            date: input.date,
+            breakfasts: input.breakfasts,
+            lunches: input.lunches,
+            dinners: input.dinners,
+            note: input.note
         )
     }
 

--- a/Cookle/Sources/Diary/Services/DiaryService.swift
+++ b/Cookle/Sources/Diary/Services/DiaryService.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum DiaryService {
+    static func create(
+        context: ModelContext,
+        date: Date,
+        breakfasts: [Recipe],
+        lunches: [Recipe],
+        dinners: [Recipe],
+        note: String
+    ) -> Diary {
+        let objects = zip(breakfasts.indices, breakfasts).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .breakfast, order: index + 1)
+        } + zip(lunches.indices, lunches).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .lunch, order: index + 1)
+        } + zip(dinners.indices, dinners).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .dinner, order: index + 1)
+        }
+        return Diary.create(
+            context: context,
+            date: date,
+            objects: objects,
+            note: note
+        )
+    }
+
+    static func update(
+        context: ModelContext,
+        diary: Diary,
+        date: Date,
+        breakfasts: [Recipe],
+        lunches: [Recipe],
+        dinners: [Recipe],
+        note: String
+    ) {
+        let objects = zip(breakfasts.indices, breakfasts).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .breakfast, order: index + 1)
+        } + zip(lunches.indices, lunches).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .lunch, order: index + 1)
+        } + zip(dinners.indices, dinners).map { index, recipe in
+            DiaryObject.create(context: context, recipe: recipe, type: .dinner, order: index + 1)
+        }
+        diary.update(
+            date: date,
+            objects: objects,
+            note: note
+        )
+    }
+}
+

--- a/Cookle/Sources/Main/Intents/OpenCookleIntent.swift
+++ b/Cookle/Sources/Main/Intents/OpenCookleIntent.swift
@@ -20,7 +20,9 @@ struct OpenCookleIntent: AppIntent, IntentPerformer {
         true
     }
 
-    static func perform(_: Input) throws -> Output {}
+    static func perform(_: Input) throws -> Output {
+        try MainService.open()
+    }
 
     func perform() throws -> some IntentResult {
         try Self.perform(())

--- a/Cookle/Sources/Main/Services/MainService.swift
+++ b/Cookle/Sources/Main/Services/MainService.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@MainActor
+enum MainService {
+    static func open() throws {}
+}
+

--- a/Cookle/Sources/Recipe/Intents/InferRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/InferRecipeIntent.swift
@@ -22,37 +22,7 @@ struct InferRecipeIntent: AppIntent, IntentPerformer {
     private var text: String
 
     static func perform(_ input: Input) async throws -> Output {
-        let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
-        let locale = Locale.current
-        let languageName = locale.localizedString(forLanguageCode: languageCode) ?? "English"
-
-        let instructions = """
-            You are a professional chef and culinary expert running a recipe website.
-            Kindly and thoroughly teach users how to prepare recipes, making your explanations easy to follow and friendly for home cooks of any skill level.
-            """
-        let session = LanguageModelSession(instructions: instructions)
-
-        let prompt = """
-            Analyze the following text and provide a recipe form. Please respond in \(languageName).
-            """ + "\n" + input
-        let inferred = try await session.respond(
-            to: prompt,
-            generating: InferredRecipe.self
-        ).content
-
-        return .init(
-            id: UUID().uuidString,
-            name: inferred.name,
-            photos: [],
-            servingSize: inferred.servingSize,
-            cookingTime: inferred.cookingTime,
-            ingredients: inferred.ingredients.map { ($0.ingredient, $0.amount) },
-            steps: inferred.steps,
-            categories: inferred.categories,
-            note: inferred.note,
-            createdTimestamp: .now,
-            modifiedTimestamp: .now
-        )
+        try await RecipeService.infer(text: input)
     }
 
     func perform() async throws -> some IntentResult {

--- a/Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift
@@ -23,19 +23,7 @@ struct SearchRecipesIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, text) = input
-        var recipes = try context.fetch(
-            .recipes(.nameContains(text))
-        )
-        let ingredients = try context.fetch(
-            text.count < 3 ? .ingredients(.valueIs(text)) : .ingredients(.valueContains(text))
-        )
-        let categories = try context.fetch(
-            text.count < 3 ? .categories(.valueIs(text)) : .categories(.valueContains(text))
-        )
-        recipes += ingredients.flatMap(\.recipes.orEmpty)
-        recipes += categories.flatMap(\.recipes.orEmpty)
-        return Array(Set(recipes))
+        try RecipeService.search(context: input.context, text: input.searchText)
     }
 
     func perform() throws -> some ReturnsValue<[RecipeEntity]> {

--- a/Cookle/Sources/Recipe/Intents/ShowLastOpenedRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/ShowLastOpenedRecipeIntent.swift
@@ -21,12 +21,7 @@ struct ShowLastOpenedRecipeIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) throws -> Output {
-        let context = input
-        guard let lastOpenedRecipeID = AppStorage(.lastOpenedRecipeID).wrappedValue else {
-            return nil
-        }
-        let id = try PersistentIdentifier(base64Encoded: lastOpenedRecipeID)
-        return try context.fetchFirst(.recipes(.idIs(id)))
+        try RecipeService.lastOpenedRecipe(context: input)
     }
 
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {

--- a/Cookle/Sources/Recipe/Intents/ShowRandomRecipeIntent.swift
+++ b/Cookle/Sources/Recipe/Intents/ShowRandomRecipeIntent.swift
@@ -21,8 +21,7 @@ struct ShowRandomRecipeIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) throws -> Output {
-        let context = input
-        return try context.fetchRandom(.recipes(.all))
+        try RecipeService.randomRecipe(context: input)
     }
 
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {

--- a/Cookle/Sources/Recipe/Services/RecipeService.swift
+++ b/Cookle/Sources/Recipe/Services/RecipeService.swift
@@ -1,7 +1,7 @@
 import Foundation
+import FoundationModels
 import SwiftData
 import SwiftUI
-import FoundationModels
 
 @MainActor
 enum RecipeService {
@@ -36,6 +36,7 @@ enum RecipeService {
         return Array(Set(recipes))
     }
 
+    @available(iOS 26.0, *)
     static func infer(text: String) async throws -> RecipeEntity {
         let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
         let locale = Locale.current
@@ -70,4 +71,3 @@ enum RecipeService {
         )
     }
 }
-

--- a/Cookle/Sources/Recipe/Services/RecipeService.swift
+++ b/Cookle/Sources/Recipe/Services/RecipeService.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SwiftData
+import SwiftUI
+import FoundationModels
+
+@MainActor
+enum RecipeService {
+    static func lastOpenedRecipe(context: ModelContext) throws -> Recipe? {
+        guard let lastOpenedRecipeID = AppStorage(.lastOpenedRecipeID).wrappedValue else {
+            return nil
+        }
+        let id = try PersistentIdentifier(base64Encoded: lastOpenedRecipeID)
+        return try context.fetchFirst(.recipes(.idIs(id)))
+    }
+
+    static func randomRecipe(context: ModelContext) throws -> Recipe? {
+        try context.fetchRandom(.recipes(.all))
+    }
+
+    static func search(context: ModelContext, text: String) throws -> [Recipe] {
+        var recipes = try context.fetch(
+            .recipes(.nameContains(text))
+        )
+        let ingredients = try context.fetch(
+            text.count < 3
+                ? .ingredients(.valueIs(text))
+                : .ingredients(.valueContains(text))
+        )
+        let categories = try context.fetch(
+            text.count < 3
+                ? .categories(.valueIs(text))
+                : .categories(.valueContains(text))
+        )
+        recipes += ingredients.flatMap(\.recipes.orEmpty)
+        recipes += categories.flatMap(\.recipes.orEmpty)
+        return Array(Set(recipes))
+    }
+
+    static func infer(text: String) async throws -> RecipeEntity {
+        let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
+        let locale = Locale.current
+        let languageName = locale.localizedString(forLanguageCode: languageCode) ?? "English"
+
+        let instructions = """
+            You are a professional chef and culinary expert running a recipe website.
+            Kindly and thoroughly teach users how to prepare recipes, making your explanations easy to follow and friendly for home cooks of any skill level.
+            """
+        let session = LanguageModelSession(instructions: instructions)
+
+        let prompt = """
+            Analyze the following text and provide a recipe form. Please respond in \(languageName).
+            """ + "\n" + text
+        let inferred = try await session.respond(
+            to: prompt,
+            generating: InferredRecipe.self
+        ).content
+
+        return .init(
+            id: UUID().uuidString,
+            name: inferred.name,
+            photos: [],
+            servingSize: inferred.servingSize,
+            cookingTime: inferred.cookingTime,
+            ingredients: inferred.ingredients.map { ($0.ingredient, $0.amount) },
+            steps: inferred.steps,
+            categories: inferred.categories,
+            note: inferred.note,
+            createdTimestamp: .now,
+            modifiedTimestamp: .now
+        )
+    }
+}
+

--- a/Cookle/Sources/Search/Intents/ShowSearchResultIntent.swift
+++ b/Cookle/Sources/Search/Intents/ShowSearchResultIntent.swift
@@ -23,24 +23,7 @@ struct ShowSearchResultIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) throws -> Output {
-        let searchText = input.text
-        var recipes = try input.context.fetch(
-            .recipes(.nameContains(searchText))
-        )
-        let ingredients = try input.context.fetch(
-            searchText.count < 3
-                ? .ingredients(.valueIs(searchText))
-                : .ingredients(.valueContains(searchText))
-        )
-        let categories = try input.context.fetch(
-            searchText.count < 3
-                ? .categories(.valueIs(searchText))
-                : .categories(.valueContains(searchText))
-        )
-        recipes += ingredients.flatMap(\.recipes.orEmpty)
-        recipes += categories.flatMap(\.recipes.orEmpty)
-        recipes = Array(Set(recipes))
-        return recipes
+        try SearchService.search(context: input.context, text: input.text)
     }
 
     func perform() throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {

--- a/Cookle/Sources/Search/Services/SearchService.swift
+++ b/Cookle/Sources/Search/Services/SearchService.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum SearchService {
+    static func search(context: ModelContext, text: String) throws -> [Recipe] {
+        var recipes = try context.fetch(
+            .recipes(.nameContains(text))
+        )
+        let ingredients = try context.fetch(
+            text.count < 3
+                ? .ingredients(.valueIs(text))
+                : .ingredients(.valueContains(text))
+        )
+        let categories = try context.fetch(
+            text.count < 3
+                ? .categories(.valueIs(text))
+                : .categories(.valueContains(text))
+        )
+        recipes += ingredients.flatMap(\.recipes.orEmpty)
+        recipes += categories.flatMap(\.recipes.orEmpty)
+        recipes = Array(Set(recipes))
+        return recipes
+    }
+}
+


### PR DESCRIPTION
## Summary
- add service skeletons
- move intent logic to MainService, SearchService, RecipeService, and DiaryService

## Testing
- `pre-commit run --files Cookle/Sources/Main/Services/MainService.swift Cookle/Sources/Main/Intents/OpenCookleIntent.swift` *(fails: error: RPC failed; HTTP 403)*
- `pre-commit run --files Cookle/Sources/Search/Services/SearchService.swift Cookle/Sources/Search/Intents/ShowSearchResultIntent.swift` *(fails: error: RPC failed; HTTP 403)*
- `pre-commit run --files Cookle/Sources/Recipe/Services/RecipeService.swift Cookle/Sources/Recipe/Intents/ShowLastOpenedRecipeIntent.swift Cookle/Sources/Recipe/Intents/ShowRandomRecipeIntent.swift Cookle/Sources/Recipe/Intents/SearchRecipesIntent.swift Cookle/Sources/Recipe/Intents/InferRecipeIntent.swift` *(fails: error: RPC failed; HTTP 403)*
- `pre-commit run --files Cookle/Sources/Diary/Services/DiaryService.swift Cookle/Sources/Diary/Intents/CreateDiaryIntent.swift Cookle/Sources/Diary/Intents/UpdateDiaryIntent.swift` *(fails: error: RPC failed; HTTP 403)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68980d9d167c8320863f2512cd1ff6db