### PR TITLE
[codex] Modernize Cookle SwiftUI surfaces

### DIFF
--- a/Cookle/Resources/Localizable.xcstrings
+++ b/Cookle/Resources/Localizable.xcstrings
@@ -390,6 +390,40 @@
         }
       }
     },
+    "Add Diary" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Diary"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir diario"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un journal"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日記を追加"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加日记"
+          }
+        }
+      }
+    },
     "Add Photo" : {
       "localizations" : {
         "en" : {
@@ -1103,6 +1137,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消计时器"
+          }
+        }
+      }
+    },
+    "Clear Search" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Search"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar búsqueda"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer la recherche"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索をクリア"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除搜索"
+          }
+        }
+      }
+    },
+    "Close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
           }
         }
       }

--- a/Cookle/Sources/Common/Extensions/View+CookleGlassButtonStyle.swift
+++ b/Cookle/Sources/Common/Extensions/View+CookleGlassButtonStyle.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension View {
+    func cookleGlassButtonStyle(isProminent: Bool = false) -> some View {
+        modifier(
+            CookleGlassButtonStyleModifier(
+                isProminent: isProminent
+            )
+        )
+    }
+}

--- a/Cookle/Sources/Common/Extensions/View+CookleGlassControl.swift
+++ b/Cookle/Sources/Common/Extensions/View+CookleGlassControl.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension View {
+    func cookleGlassControl<S: Shape>(
+        in shape: S,
+        isInteractive: Bool = true
+    ) -> some View {
+        modifier(
+            CookleGlassControlModifier(
+                shape: shape,
+                isInteractive: isInteractive
+            )
+        )
+    }
+}

--- a/Cookle/Sources/Common/Extensions/View+CookleGlassSurface.swift
+++ b/Cookle/Sources/Common/Extensions/View+CookleGlassSurface.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension View {
+    func cookleGlassSurface<S: Shape>(
+        in shape: S
+    ) -> some View {
+        modifier(
+            CookleGlassSurfaceModifier(
+                shape: shape
+            )
+        )
+    }
+}

--- a/Cookle/Sources/Common/Styles/CookleGlassButtonStyleModifier.swift
+++ b/Cookle/Sources/Common/Styles/CookleGlassButtonStyleModifier.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct CookleGlassButtonStyleModifier: ViewModifier {
+    let isProminent: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            if isProminent {
+                content.buttonStyle(.glassProminent)
+            } else {
+                content.buttonStyle(.glass)
+            }
+        } else if isProminent {
+            content.buttonStyle(.borderedProminent)
+        } else {
+            content.buttonStyle(.bordered)
+        }
+    }
+}

--- a/Cookle/Sources/Common/Styles/CookleGlassControlModifier.swift
+++ b/Cookle/Sources/Common/Styles/CookleGlassControlModifier.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CookleGlassControlModifier<S: Shape>: ViewModifier {
+    let shape: S
+    let isInteractive: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(
+                .regular.interactive(isInteractive),
+                in: shape
+            )
+        } else {
+            content.background(
+                .thinMaterial,
+                in: shape
+            )
+        }
+    }
+}

--- a/Cookle/Sources/Common/Styles/CookleGlassSurfaceModifier.swift
+++ b/Cookle/Sources/Common/Styles/CookleGlassSurfaceModifier.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct CookleGlassSurfaceModifier<S: Shape>: ViewModifier {
+    let shape: S
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(
+                .regular,
+                in: shape
+            )
+        } else {
+            content.background(
+                .background,
+                in: shape
+            )
+        }
+    }
+}

--- a/Cookle/Sources/Diary/Components/AddDiaryButton.swift
+++ b/Cookle/Sources/Diary/Components/AddDiaryButton.swift
@@ -19,9 +19,9 @@ struct AddDiaryButton: View {
             }
         } label: {
             Label {
-                Text("Add")
+                Text("Add Diary")
             } icon: {
-                Image(systemName: "book")
+                Image(systemName: "plus")
                     .accessibilityHidden(true)
             }
         }

--- a/Cookle/Sources/Diary/Views/DiaryFormRecipeListView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryFormRecipeListView.swift
@@ -9,6 +9,10 @@ import SwiftData
 import SwiftUI
 
 struct DiaryFormRecipeListView: View {
+    private enum Layout {
+        static let searchFieldVerticalPadding: CGFloat = 8
+    }
+
     @Environment(\.dismiss)
     private var dismiss
 
@@ -19,25 +23,26 @@ struct DiaryFormRecipeListView: View {
 
     @State private var temporarySelection = Set<Recipe>()
     @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
 
     private let type: DiaryObjectType
 
     var body: some View {
-        List(
-            recipes.filter { recipe in
-                guard !searchText.isEmpty else {
-                    return true
-                }
-                return recipe.name.normalizedContains(searchText)
-            },
-            selection: $temporarySelection
-        ) { recipe in
-            RecipeLabel()
-                .labelStyle(.titleAndLargeIcon)
-                .tag(recipe)
-                .environment(recipe)
+        VStack(spacing: 0) {
+            if !recipes.isEmpty {
+                CookleSearchField(
+                    text: $searchText,
+                    isFocused: $isSearchFocused
+                )
+                .padding(.horizontal)
+                .padding(.vertical, Layout.searchFieldVerticalPadding)
+
+                Divider()
+            }
+
+            contentView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .searchable(text: $searchText)
         .environment(\.editMode, .constant(.active))
         .navigationTitle(type.title)
         .toolbar {
@@ -56,6 +61,49 @@ struct DiaryFormRecipeListView: View {
         _selection = selection
         _temporarySelection = .init(initialValue: selection.wrappedValue)
         self.type = type
+    }
+}
+
+private extension DiaryFormRecipeListView {
+    @ViewBuilder var contentView: some View {
+        if !filteredRecipes.isEmpty {
+            recipeList
+        } else {
+            emptyStateView
+        }
+    }
+
+    var recipeList: some View {
+        List(
+            filteredRecipes,
+            selection: $temporarySelection
+        ) { recipe in
+            RecipeLabel()
+                .labelStyle(.titleAndLargeIcon)
+                .tag(recipe)
+                .environment(recipe)
+        }
+    }
+
+    @ViewBuilder var emptyStateView: some View {
+        if !recipes.isEmpty {
+            ContentUnavailableView.search(text: searchText)
+        } else {
+            ContentUnavailableView {
+                Label("No Recipes Yet", systemImage: "book.pages")
+            } description: {
+                Text("Add a recipe to start building your collection.")
+            }
+        }
+    }
+
+    var filteredRecipes: [Recipe] {
+        recipes.filter { recipe in
+            guard !searchText.isEmpty else {
+                return true
+            }
+            return recipe.name.normalizedContains(searchText)
+        }
     }
 }
 

--- a/Cookle/Sources/Diary/Views/DiaryFormView.swift
+++ b/Cookle/Sources/Diary/Views/DiaryFormView.swift
@@ -97,9 +97,15 @@ struct DiaryFormView: View {
         @Bindable var model = model
 
         return Section {
-            TextField(text: $model.note, axis: .vertical) {
-                Text("Classic spaghetti carbonara and warm beef stew for a comforting end to the day.")
-            }
+            TextField(
+                "Note",
+                text: $model.note,
+                prompt: Text("Classic spaghetti carbonara and warm beef stew for a comforting end to the day."),
+                axis: .vertical
+            )
+            .accessibilityValue(
+                model.note.isEmpty ? Text(verbatim: "") : Text(verbatim: model.note)
+            )
         } header: {
             Text("Note")
         }

--- a/Cookle/Sources/Recipe/Components/AddRecipeButton.swift
+++ b/Cookle/Sources/Recipe/Components/AddRecipeButton.swift
@@ -31,7 +31,7 @@ struct AddRecipeButton: View {
             Label {
                 Text("Add Recipe")
             } icon: {
-                Image(systemName: "book.pages")
+                Image(systemName: "plus")
                     .accessibilityHidden(true)
             }
         }

--- a/Cookle/Sources/Recipe/Components/CookingSessionTimerSection.swift
+++ b/Cookle/Sources/Recipe/Components/CookingSessionTimerSection.swift
@@ -126,19 +126,19 @@ private extension CookingSessionTimerSection {
         Button("Repeat") {
             cookingSessionStore.repeatTimer()
         }
-        .buttonStyle(.borderedProminent)
+        .cookleGlassButtonStyle(isProminent: true)
 
         if snapshot.hasNextStep {
             Button("Next Step") {
                 cookingSessionStore.advanceFromTimerFollowUp()
             }
-            .buttonStyle(.bordered)
+            .cookleGlassButtonStyle()
         }
 
         Button("Cancel Timer") {
             cookingSessionStore.cancelTimer()
         }
-        .buttonStyle(.bordered)
+        .cookleGlassButtonStyle()
     }
 
     @ViewBuilder
@@ -171,7 +171,7 @@ private extension CookingSessionTimerSection {
                 Text("\(minutes) min")
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.borderedProminent)
+            .cookleGlassButtonStyle(isProminent: true)
         } else {
             Button {
                 cookingSessionStore.startTimer(
@@ -181,7 +181,7 @@ private extension CookingSessionTimerSection {
                 Text("\(minutes) min")
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.bordered)
+            .cookleGlassButtonStyle()
         }
     }
 
@@ -209,7 +209,7 @@ private extension CookingSessionTimerSection {
             ) {
                 cookingSessionStore.cancelTimer()
             }
-            .buttonStyle(.bordered)
+            .cookleGlassButtonStyle()
         }
     }
 

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormCategoriesSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormCategoriesSection.swift
@@ -5,44 +5,109 @@
 //  Created by Hiromu Nakano on 2024/04/11.
 //
 
+import Foundation
 import SwiftData
 import SwiftUI
 
 struct RecipeFormCategoriesSection: View {
     @Binding private var categories: [String]
 
-    @FocusState private var focusedIndex: Int?
+    @FocusState private var focusedRowID: UUID?
+    @State private var categoryRowIDs: [UUID]
 
     var body: some View {
         Section {
-            ForEach(categories.indices, id: \.self) { index in
-                TextField(text: $categories[index], axis: .vertical) {
+            ForEach(categoryRows) { row in
+                TextField(text: categoryBinding(at: row.index), axis: .vertical) {
                     Text("Italian")
                 }
-                .focused($focusedIndex, equals: index)
+                .focused($focusedRowID, equals: row.id)
                 .toolbar {
                     ToolbarItem(placement: .keyboard) {
-                        if focusedIndex == index {
-                            SuggestionButtons<Category>(input: $categories[index])
+                        if focusedRowID == row.id {
+                            SuggestionButtons<Category>(
+                                input: categoryBinding(at: row.index)
+                            )
                         }
                     }
                 }
             }
             .onDelete { offsets in
-                categories.remove(atOffsets: offsets)
+                deleteCategories(atOffsets: offsets)
             }
         } header: {
             Text("Categories")
         }
+        .onAppear {
+            synchronizeCategoryRowIDs()
+        }
         .onChange(of: categories) {
-            categories = RecipeFormPlaceholderRows.normalizedStrings(
-                categories
-            )
+            normalizeCategories()
+            synchronizeCategoryRowIDs()
         }
     }
 
     init(_ categories: Binding<[String]>) {
         self._categories = categories
+        self._categoryRowIDs = State(
+            initialValue: RecipeFormStableRowIDs.make(
+                count: categories.wrappedValue.count
+            )
+        )
+    }
+}
+
+private extension RecipeFormCategoriesSection {
+    var categoryRows: [RecipeFormStableRowIDs.IndexedRow] {
+        RecipeFormStableRowIDs.indexedRows(
+            rowIDs: categoryRowIDs,
+            count: categories.count
+        )
+    }
+
+    func categoryBinding(at index: Int) -> Binding<String> {
+        .init(
+            get: {
+                categories[index]
+            },
+            set: { value in
+                categories[index] = value
+            }
+        )
+    }
+
+    func deleteCategories(atOffsets offsets: IndexSet) {
+        categories.remove(atOffsets: offsets)
+        categoryRowIDs.remove(atOffsets: offsets)
+        clearStaleFocus()
+    }
+
+    func normalizeCategories() {
+        let normalizedCategories = RecipeFormPlaceholderRows.normalizedStrings(
+            categories
+        )
+        guard normalizedCategories != categories else {
+            return
+        }
+
+        categories = normalizedCategories
+    }
+
+    func synchronizeCategoryRowIDs() {
+        RecipeFormStableRowIDs.synchronize(
+            &categoryRowIDs,
+            count: categories.count
+        )
+        clearStaleFocus()
+    }
+
+    func clearStaleFocus() {
+        guard let focusedRowID,
+              categoryRowIDs.contains(focusedRowID) == false else {
+            return
+        }
+
+        self.focusedRowID = nil
     }
 }
 

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormCategoriesSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormCategoriesSection.swift
@@ -18,9 +18,12 @@ struct RecipeFormCategoriesSection: View {
     var body: some View {
         Section {
             ForEach(categoryRows) { row in
-                TextField(text: categoryBinding(at: row.index), axis: .vertical) {
-                    Text("Italian")
-                }
+                TextField(
+                    "Category",
+                    text: categoryBinding(at: row.index),
+                    prompt: Text("Italian"),
+                    axis: .vertical
+                )
                 .focused($focusedRowID, equals: row.id)
                 .toolbar {
                     ToolbarItem(placement: .keyboard) {

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormCookingTimeSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormCookingTimeSection.swift
@@ -13,10 +13,11 @@ struct RecipeFormCookingTimeSection: View {
     var body: some View {
         Section {
             HStack {
-                TextField(text: $cookingTime) {
-                    Text("30")
-                }
-                .keyboardType(.numberPad)
+                TextField("Cooking Time", text: $cookingTime, prompt: Text("30"))
+                    .keyboardType(.numberPad)
+                    .accessibilityValue(
+                        cookingTime.isEmpty ? Text(verbatim: "") : Text(verbatim: cookingTime)
+                    )
                 Text("minutes")
             }
         } header: {

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormIngredientsSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormIngredientsSection.swift
@@ -20,25 +20,10 @@ struct RecipeFormIngredientsSection: View {
     var body: some View {
         Section {
             ForEach(ingredientRows) { row in
-                HStack(alignment: .top) {
-                    TextField(text: ingredientNameBinding(at: row.index), axis: .vertical) {
-                        Text("Spaghetti")
+                ingredientRow(for: row)
+                    .toolbar {
+                        ingredientSuggestionToolbarItem(for: row)
                     }
-                    .focused($focusedRowID, equals: row.id)
-                    TextField(text: ingredientAmountBinding(at: row.index)) {
-                        Text("200g")
-                    }
-                    .multilineTextAlignment(.trailing)
-                }
-                .toolbar {
-                    ToolbarItem(placement: .keyboard) {
-                        if focusedRowID == row.id {
-                            SuggestionButtons<Ingredient>(
-                                input: ingredientNameBinding(at: row.index)
-                            )
-                        }
-                    }
-                }
             }
             .onMove { sourceOffsets, destinationOffset in
                 moveIngredients(
@@ -83,6 +68,39 @@ private extension RecipeFormIngredientsSection {
             rowIDs: ingredientRowIDs,
             count: ingredients.count
         )
+    }
+
+    func ingredientRow(
+        for row: RecipeFormStableRowIDs.IndexedRow
+    ) -> some View {
+        HStack(alignment: .top) {
+            TextField(
+                "Ingredient",
+                text: ingredientNameBinding(at: row.index),
+                prompt: Text("Spaghetti"),
+                axis: .vertical
+            )
+            .focused($focusedRowID, equals: row.id)
+            TextField(
+                "Amount",
+                text: ingredientAmountBinding(at: row.index),
+                prompt: Text("200g")
+            )
+            .multilineTextAlignment(.trailing)
+        }
+    }
+
+    @ToolbarContentBuilder
+    func ingredientSuggestionToolbarItem(
+        for row: RecipeFormStableRowIDs.IndexedRow
+    ) -> some ToolbarContent {
+        ToolbarItem(placement: .keyboard) {
+            if focusedRowID == row.id {
+                SuggestionButtons<Ingredient>(
+                    input: ingredientNameBinding(at: row.index)
+                )
+            }
+        }
     }
 
     func ingredientNameBinding(at index: Int) -> Binding<String> {

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormIngredientsSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormIngredientsSection.swift
@@ -5,6 +5,7 @@
 //  Created by Hiromu Nakano on 2024/05/03.
 //
 
+import Foundation
 import SwiftData
 import SwiftUI
 
@@ -13,34 +14,40 @@ typealias RecipeFormIngredient = RecipeFormIngredientInput
 struct RecipeFormIngredientsSection: View {
     @Binding private var ingredients: [RecipeFormIngredient]
 
-    @FocusState private var focusedIndex: Int?
+    @FocusState private var focusedRowID: UUID?
+    @State private var ingredientRowIDs: [UUID]
 
     var body: some View {
         Section {
-            ForEach(ingredients.indices, id: \.self) { index in
+            ForEach(ingredientRows) { row in
                 HStack(alignment: .top) {
-                    TextField(text: $ingredients[index].ingredient, axis: .vertical) {
+                    TextField(text: ingredientNameBinding(at: row.index), axis: .vertical) {
                         Text("Spaghetti")
                     }
-                    .focused($focusedIndex, equals: index)
-                    TextField(text: $ingredients[index].amount) {
+                    .focused($focusedRowID, equals: row.id)
+                    TextField(text: ingredientAmountBinding(at: row.index)) {
                         Text("200g")
                     }
                     .multilineTextAlignment(.trailing)
                 }
                 .toolbar {
                     ToolbarItem(placement: .keyboard) {
-                        if focusedIndex == index {
-                            SuggestionButtons<Ingredient>(input: $ingredients[index].ingredient)
+                        if focusedRowID == row.id {
+                            SuggestionButtons<Ingredient>(
+                                input: ingredientNameBinding(at: row.index)
+                            )
                         }
                     }
                 }
             }
             .onMove { sourceOffsets, destinationOffset in
-                ingredients.move(fromOffsets: sourceOffsets, toOffset: destinationOffset)
+                moveIngredients(
+                    fromOffsets: sourceOffsets,
+                    toOffset: destinationOffset
+                )
             }
             .onDelete { offsets in
-                ingredients.remove(atOffsets: offsets)
+                deleteIngredients(atOffsets: offsets)
             }
         } header: {
             HStack {
@@ -51,20 +58,101 @@ struct RecipeFormIngredientsSection: View {
                     .textCase(nil)
             }
         }
-        .onChange(of: ingredients.map(\.ingredient)) {
-            ingredients = RecipeFormPlaceholderRows.normalizedIngredients(
-                ingredients
-            )
+        .onAppear {
+            synchronizeIngredientRowIDs()
         }
-        .onChange(of: ingredients.map(\.amount)) {
-            ingredients = RecipeFormPlaceholderRows.normalizedIngredients(
-                ingredients
-            )
+        .onChange(of: ingredients) {
+            normalizeIngredients()
+            synchronizeIngredientRowIDs()
         }
     }
 
     init(_ ingredients: Binding<[RecipeFormIngredient]>) {
         self._ingredients = ingredients
+        self._ingredientRowIDs = State(
+            initialValue: RecipeFormStableRowIDs.make(
+                count: ingredients.wrappedValue.count
+            )
+        )
+    }
+}
+
+private extension RecipeFormIngredientsSection {
+    var ingredientRows: [RecipeFormStableRowIDs.IndexedRow] {
+        RecipeFormStableRowIDs.indexedRows(
+            rowIDs: ingredientRowIDs,
+            count: ingredients.count
+        )
+    }
+
+    func ingredientNameBinding(at index: Int) -> Binding<String> {
+        .init(
+            get: {
+                ingredients[index].ingredient
+            },
+            set: { value in
+                ingredients[index].ingredient = value
+            }
+        )
+    }
+
+    func ingredientAmountBinding(at index: Int) -> Binding<String> {
+        .init(
+            get: {
+                ingredients[index].amount
+            },
+            set: { value in
+                ingredients[index].amount = value
+            }
+        )
+    }
+
+    func moveIngredients(
+        fromOffsets sourceOffsets: IndexSet,
+        toOffset destinationOffset: Int
+    ) {
+        ingredients.move(
+            fromOffsets: sourceOffsets,
+            toOffset: destinationOffset
+        )
+        ingredientRowIDs.move(
+            fromOffsets: sourceOffsets,
+            toOffset: destinationOffset
+        )
+    }
+
+    func deleteIngredients(atOffsets offsets: IndexSet) {
+        ingredients.remove(atOffsets: offsets)
+        ingredientRowIDs.remove(atOffsets: offsets)
+        clearStaleFocus()
+    }
+
+    func normalizeIngredients() {
+        let normalizedIngredients = RecipeFormPlaceholderRows.normalizedIngredients(
+            ingredients
+        )
+        guard normalizedIngredients != ingredients else {
+            return
+        }
+
+        ingredients = normalizedIngredients
+    }
+
+    func synchronizeIngredientRowIDs() {
+        RecipeFormStableRowIDs.synchronize(
+            &ingredientRowIDs,
+            count: ingredients.count
+        )
+        clearStaleFocus()
+    }
+
+    func clearStaleFocus() {
+        guard let focusedRowID,
+              ingredientRowIDs.contains(focusedRowID) == false else {
+            return
+        }
+
+        self.focusedRowID = nil
     }
 }
 

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormNameSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormNameSection.swift
@@ -12,9 +12,10 @@ struct RecipeFormNameSection: View {
 
     var body: some View {
         Section {
-            TextField(text: $name) {
-                Text("Spaghetti Carbonara")
-            }
+            TextField("Name", text: $name, prompt: Text("Spaghetti Carbonara"))
+                .accessibilityValue(
+                    name.isEmpty ? Text(verbatim: "") : Text(verbatim: name)
+                )
         } header: {
             HStack {
                 Text("Name")

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormNoteSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormNoteSection.swift
@@ -12,9 +12,15 @@ struct RecipeFormNoteSection: View {
 
     var body: some View {
         Section {
-            TextField(text: $note, axis: .vertical) {
-                Text("Use freshly grated Parmesan for the best flavor.")
-            }
+            TextField(
+                "Note",
+                text: $note,
+                prompt: Text("Use freshly grated Parmesan for the best flavor."),
+                axis: .vertical
+            )
+            .accessibilityValue(
+                note.isEmpty ? Text(verbatim: "") : Text(verbatim: note)
+            )
         } header: {
             Text("Note")
         }

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotoRemovalResolver.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotoRemovalResolver.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct RecipeFormPhotoRemovalResolver {
+    let recipe: Recipe
+    let photos: [PhotoData]
+
+    func behavior(for index: Int) -> RecipePhotoRemovalBehavior? {
+        guard photos.indices.contains(index),
+              let persistedPhotoObject = persistedPhotoObject(
+                for: index
+              ) else {
+            return nil
+        }
+
+        return .persistedPhotoBehavior(
+            draftReferenceCount: draftReferenceCount(
+                for: index
+            ),
+            persistedReferenceCountOutsideRecipe:
+                persistedReferenceCountOutsideRecipe(
+                    for: persistedPhotoObject
+                )
+        )
+    }
+
+    func persistedPhotoObject(for index: Int) -> PhotoObject? {
+        let photoData = photos[index]
+        let matchingPhotoObjects = recipe.orderedPhotoObjects.filter { photoObject in
+            guard let photo = photoObject.photo else {
+                return false
+            }
+
+            return photo.data == photoData.data
+                && photo.source == photoData.source
+        }
+        let matchingDraftCount = photos.prefix(
+            index + 1
+        )
+        .filter { currentPhoto in
+            currentPhoto.data == photoData.data
+                && currentPhoto.source == photoData.source
+        }
+        .count
+
+        guard matchingDraftCount <= matchingPhotoObjects.count else {
+            return nil
+        }
+
+        return matchingPhotoObjects[matchingDraftCount - 1]
+    }
+
+    func draftReferenceCount(for index: Int) -> Int {
+        let photoData = photos[index]
+        return photos.filter { currentPhoto in
+            currentPhoto.data == photoData.data
+                && currentPhoto.source == photoData.source
+        }
+        .count
+    }
+
+    func persistedReferenceCountOutsideRecipe(
+        for photoObject: PhotoObject
+    ) -> Int {
+        guard let photo = photoObject.photo else {
+            return .zero
+        }
+
+        let currentRecipeReferenceCount = recipe.orderedPhotoObjects
+            .filter { currentPhotoObject in
+                guard let currentPhoto = currentPhotoObject.photo else {
+                    return false
+                }
+
+                return currentPhoto.data == photo.data
+                    && currentPhoto.source == photo.source
+            }
+            .count
+        let totalReferenceCount = (photo.objects ?? []).count
+
+        return max(
+            .zero,
+            totalReferenceCount - currentRecipeReferenceCount
+        )
+    }
+}

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotoThumbnailView.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotoThumbnailView.swift
@@ -41,7 +41,9 @@ struct RecipeFormPhotoThumbnailView: View {
                     .font(.title3)
                     .foregroundStyle(.primary)
                     .padding(actionButtonPadding)
-                    .background(.thinMaterial, in: .circle)
+                    .cookleGlassControl(
+                        in: Circle()
+                    )
             }
             .accessibilityLabel(Text("Photo Actions"))
             .padding(actionButtonPadding)

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotosSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormPhotosSection.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MHDesign
 import PhotosUI
 import SwiftData
@@ -24,6 +25,7 @@ struct RecipeFormPhotosSection: View {
     @State private var isImagePlaygroundPresented = false
     @State private var pendingPhotoRemovalIndex: Int?
     @State private var isPhotoRemovalDialogPresented = false
+    @State private var photoRowIDs: [UUID]
 
     var body: some View {
         Section {
@@ -33,6 +35,12 @@ struct RecipeFormPhotosSection: View {
         }
         .onChange(of: photosPickerItems) {
             applySelectedPhotoItems()
+        }
+        .onAppear {
+            synchronizePhotoRowIDs()
+        }
+        .onChange(of: photos.count) {
+            synchronizePhotoRowIDs()
         }
         .confirmationDialog(
             Text(photoRemovalTitle),
@@ -105,8 +113,8 @@ struct RecipeFormPhotosSection: View {
     }
 
     var editModeContent: some View {
-        ForEach(photos, id: \.data) { photo in
-            if let image = UIImage(data: photo.data) {
+        ForEach(photoRows) { row in
+            if let image = UIImage(data: photos[row.index].data) {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFit()
@@ -115,10 +123,13 @@ struct RecipeFormPhotosSection: View {
             }
         }
         .onMove { sourceOffsets, destinationOffset in
-            photos.move(fromOffsets: sourceOffsets, toOffset: destinationOffset)
+            movePhotos(
+                fromOffsets: sourceOffsets,
+                toOffset: destinationOffset
+            )
         }
         .onDelete { offsets in
-            photos.remove(atOffsets: offsets)
+            deletePhotos(atOffsets: offsets)
         }
     }
 
@@ -141,6 +152,11 @@ struct RecipeFormPhotosSection: View {
     ) {
         _photos = photos
         self.addPhotoTip = addPhotoTip
+        _photoRowIDs = State(
+            initialValue: RecipeFormStableRowIDs.make(
+                count: photos.wrappedValue.count
+            )
+        )
     }
 }
 
@@ -162,6 +178,13 @@ struct RecipeFormPhotosSection: View {
 private extension RecipeFormPhotosSection {
     var availablePhotoInputSources: [RecipePhotoInputSource] {
         RecipePhotoInputSource.allCases.filter(\.isAvailable)
+    }
+
+    var photoRows: [RecipeFormStableRowIDs.IndexedRow] {
+        RecipeFormStableRowIDs.indexedRows(
+            rowIDs: photoRowIDs,
+            count: photos.count
+        )
     }
 
     var addPhotoRow: some View {
@@ -227,15 +250,15 @@ private extension RecipeFormPhotosSection {
 
     @ViewBuilder
     func photoThumbnails(height: CGFloat) -> some View {
-        ForEach(Array(photos.enumerated()), id: \.offset) { index, photo in
+        ForEach(photoRows) { row in
             RecipeFormPhotoThumbnailView(
-                photo: photo,
-                index: index,
+                photo: photos[row.index],
+                index: row.index,
                 height: height,
                 cornerRadius: designMetrics.cornerRadius.control,
                 actionButtonPadding: designMetrics.spacing.inline,
                 photoRemovalBehavior: photoRemovalBehavior(
-                    for: index
+                    for: row.index
                 ),
                 pendingPhotoRemovalIndex: $pendingPhotoRemovalIndex,
                 isPhotoRemovalDialogPresented: $isPhotoRemovalDialogPresented
@@ -292,92 +315,63 @@ private extension RecipeFormPhotosSection {
     }
 
     func photoRemovalBehavior(for index: Int) -> RecipePhotoRemovalBehavior? {
-        guard let recipe,
-              let persistedPhotoObject = persistedPhotoObject(
-                for: index
-              ) else {
-            return nil
-        }
-
-        return .persistedPhotoBehavior(
-            draftReferenceCount: draftReferenceCount(
-                for: index
-            ),
-            persistedReferenceCountOutsideRecipe:
-                persistedReferenceCountOutsideRecipe(
-                    for: persistedPhotoObject,
-                    recipe: recipe
-                )
-        )
-    }
-
-    func persistedPhotoObject(for index: Int) -> PhotoObject? {
         guard let recipe else {
             return nil
         }
 
-        let photoData = photos[index]
-        let matchingPhotoObjects = recipe.orderedPhotoObjects.filter { photoObject in
-            guard let photo = photoObject.photo else {
-                return false
-            }
-
-            return photo.data == photoData.data
-                && photo.source == photoData.source
-        }
-        let matchingDraftCount = photos.prefix(
-            index + 1
+        return RecipeFormPhotoRemovalResolver(
+            recipe: recipe,
+            photos: photos
         )
-        .filter { currentPhoto in
-            currentPhoto.data == photoData.data
-                && currentPhoto.source == photoData.source
-        }
-        .count
-
-        guard matchingDraftCount <= matchingPhotoObjects.count else {
-            return nil
-        }
-
-        return matchingPhotoObjects[matchingDraftCount - 1]
-    }
-
-    func draftReferenceCount(for index: Int) -> Int {
-        let photoData = photos[index]
-        return photos.filter { currentPhoto in
-            currentPhoto.data == photoData.data
-                && currentPhoto.source == photoData.source
-        }
-        .count
-    }
-
-    func persistedReferenceCountOutsideRecipe(
-        for photoObject: PhotoObject,
-        recipe: Recipe
-    ) -> Int {
-        guard let photo = photoObject.photo else {
-            return .zero
-        }
-
-        let currentRecipeReferenceCount = recipe.orderedPhotoObjects
-            .filter { currentPhotoObject in
-                guard let currentPhoto = currentPhotoObject.photo else {
-                    return false
-                }
-
-                return currentPhoto.data == photo.data
-                    && currentPhoto.source == photo.source
-            }
-            .count
-        let totalReferenceCount = (photo.objects ?? []).count
-
-        return max(
-            .zero,
-            totalReferenceCount - currentRecipeReferenceCount
-        )
+        .behavior(for: index)
     }
 
     func removePhoto(at index: Int) {
+        guard photos.indices.contains(index) else {
+            return
+        }
+
         pendingPhotoRemovalIndex = nil
         photos.remove(at: index)
+        if photoRowIDs.indices.contains(index) {
+            photoRowIDs.remove(at: index)
+        }
+    }
+
+    func movePhotos(
+        fromOffsets sourceOffsets: IndexSet,
+        toOffset destinationOffset: Int
+    ) {
+        photos.move(
+            fromOffsets: sourceOffsets,
+            toOffset: destinationOffset
+        )
+        photoRowIDs.move(
+            fromOffsets: sourceOffsets,
+            toOffset: destinationOffset
+        )
+    }
+
+    func deletePhotos(atOffsets offsets: IndexSet) {
+        photos.remove(atOffsets: offsets)
+        photoRowIDs.remove(atOffsets: offsets)
+        clearStalePendingPhotoRemoval()
+    }
+
+    func synchronizePhotoRowIDs() {
+        RecipeFormStableRowIDs.synchronize(
+            &photoRowIDs,
+            count: photos.count
+        )
+        clearStalePendingPhotoRemoval()
+    }
+
+    func clearStalePendingPhotoRemoval() {
+        guard let pendingPhotoRemovalIndex,
+              photos.indices.contains(pendingPhotoRemovalIndex) == false else {
+            return
+        }
+
+        self.pendingPhotoRemovalIndex = nil
     }
 }

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormServingSizeSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormServingSizeSection.swift
@@ -13,10 +13,11 @@ struct RecipeFormServingSizeSection: View {
     var body: some View {
         Section {
             HStack {
-                TextField(text: $servingSize) {
-                    Text("2")
-                }
-                .keyboardType(.numberPad)
+                TextField("Serving Size", text: $servingSize, prompt: Text("2"))
+                    .keyboardType(.numberPad)
+                    .accessibilityValue(
+                        servingSize.isEmpty ? Text(verbatim: "") : Text(verbatim: servingSize)
+                    )
                 Text("servings")
             }
         } header: {

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormStableRowIDs.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormStableRowIDs.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum RecipeFormStableRowIDs {
+    struct IndexedRow: Identifiable {
+        let id: UUID
+        let index: Int
+    }
+
+    static func make(count: Int) -> [UUID] {
+        (0..<count).map { _ in
+            UUID()
+        }
+    }
+
+    static func indexedRows(
+        rowIDs: [UUID],
+        count: Int
+    ) -> [IndexedRow] {
+        zip(rowIDs, 0..<count).map { values in
+            .init(
+                id: values.0,
+                index: values.1
+            )
+        }
+    }
+
+    static func synchronize(
+        _ rowIDs: inout [UUID],
+        count: Int
+    ) {
+        if rowIDs.count < count {
+            rowIDs.append(
+                contentsOf: make(
+                    count: count - rowIDs.count
+                )
+            )
+        } else if rowIDs.count > count {
+            rowIDs.removeLast(
+                rowIDs.count - count
+            )
+        }
+    }
+}

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormStepsSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormStepsSection.swift
@@ -21,9 +21,12 @@ struct RecipeFormStepsSection: View {
                     Text((row.index + RecipeStepLayout.stepNumberOffset).description + ".")
                         .foregroundStyle(.secondary)
                         .frame(width: RecipeStepLayout.indexWidth)
-                    TextField(text: stepBinding(at: row.index), axis: .vertical) {
-                        Text("Boil water in a large pot and add salt.")
-                    }
+                    TextField(
+                        "Steps",
+                        text: stepBinding(at: row.index),
+                        prompt: Text("Boil water in a large pot and add salt."),
+                        axis: .vertical
+                    )
                     .focused($focusedRowID, equals: row.id)
                 }
             }

--- a/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormStepsSection.swift
+++ b/Cookle/Sources/Recipe/Components/RecipeForm/RecipeFormStepsSection.swift
@@ -5,29 +5,36 @@
 //  Created by Hiromu Nakano on 2024/05/03.
 //
 
+import Foundation
 import SwiftData
 import SwiftUI
 
 struct RecipeFormStepsSection: View {
     @Binding private var steps: [String]
+    @FocusState private var focusedRowID: UUID?
+    @State private var stepRowIDs: [UUID]
 
     var body: some View {
         Section {
-            ForEach(steps.indices, id: \.self) { index in
+            ForEach(stepRows) { row in
                 HStack(alignment: .top) {
-                    Text((index + RecipeStepLayout.stepNumberOffset).description + ".")
+                    Text((row.index + RecipeStepLayout.stepNumberOffset).description + ".")
                         .foregroundStyle(.secondary)
                         .frame(width: RecipeStepLayout.indexWidth)
-                    TextField(text: $steps[index], axis: .vertical) {
+                    TextField(text: stepBinding(at: row.index), axis: .vertical) {
                         Text("Boil water in a large pot and add salt.")
                     }
+                    .focused($focusedRowID, equals: row.id)
                 }
             }
             .onMove { sourceOffsets, destinationOffset in
-                steps.move(fromOffsets: sourceOffsets, toOffset: destinationOffset)
+                moveSteps(
+                    fromOffsets: sourceOffsets,
+                    toOffset: destinationOffset
+                )
             }
             .onDelete { offsets in
-                steps.remove(atOffsets: offsets)
+                deleteSteps(atOffsets: offsets)
             }
         } header: {
             HStack {
@@ -38,15 +45,90 @@ struct RecipeFormStepsSection: View {
                     .textCase(nil)
             }
         }
+        .onAppear {
+            synchronizeStepRowIDs()
+        }
         .onChange(of: steps) {
-            steps = RecipeFormPlaceholderRows.normalizedStrings(
-                steps
-            )
+            normalizeSteps()
+            synchronizeStepRowIDs()
         }
     }
 
     init(_ steps: Binding<[String]>) {
         self._steps = steps
+        self._stepRowIDs = State(
+            initialValue: RecipeFormStableRowIDs.make(
+                count: steps.wrappedValue.count
+            )
+        )
+    }
+}
+
+private extension RecipeFormStepsSection {
+    var stepRows: [RecipeFormStableRowIDs.IndexedRow] {
+        RecipeFormStableRowIDs.indexedRows(
+            rowIDs: stepRowIDs,
+            count: steps.count
+        )
+    }
+
+    func stepBinding(at index: Int) -> Binding<String> {
+        .init(
+            get: {
+                steps[index]
+            },
+            set: { value in
+                steps[index] = value
+            }
+        )
+    }
+
+    func moveSteps(
+        fromOffsets sourceOffsets: IndexSet,
+        toOffset destinationOffset: Int
+    ) {
+        steps.move(
+            fromOffsets: sourceOffsets,
+            toOffset: destinationOffset
+        )
+        stepRowIDs.move(
+            fromOffsets: sourceOffsets,
+            toOffset: destinationOffset
+        )
+    }
+
+    func deleteSteps(atOffsets offsets: IndexSet) {
+        steps.remove(atOffsets: offsets)
+        stepRowIDs.remove(atOffsets: offsets)
+        clearStaleFocus()
+    }
+
+    func normalizeSteps() {
+        let normalizedSteps = RecipeFormPlaceholderRows.normalizedStrings(
+            steps
+        )
+        guard normalizedSteps != steps else {
+            return
+        }
+
+        steps = normalizedSteps
+    }
+
+    func synchronizeStepRowIDs() {
+        RecipeFormStableRowIDs.synchronize(
+            &stepRowIDs,
+            count: steps.count
+        )
+        clearStaleFocus()
+    }
+
+    func clearStaleFocus() {
+        guard let focusedRowID,
+              stepRowIDs.contains(focusedRowID) == false else {
+            return
+        }
+
+        self.focusedRowID = nil
     }
 }
 

--- a/Cookle/Sources/Recipe/Components/SuggestionButtons.swift
+++ b/Cookle/Sources/Recipe/Components/SuggestionButtons.swift
@@ -15,20 +15,49 @@ struct SuggestionButtons<T: Tag>: View {
 
     var body: some View {
         ScrollView(.horizontal) {
-            HStack {
-                ForEach(suggestions) { suggestion in
-                    Button(suggestion.value) {
-                        input = suggestion.value
-                    }
-                    Divider()
+            if #available(iOS 26.0, *) {
+                GlassEffectContainer(
+                    spacing: SuggestionButtonsLayout.buttonSpacing
+                ) {
+                    suggestionButtonRow
                 }
+            } else {
+                suggestionButtonRow
             }
         }
+        .scrollIndicators(.hidden)
     }
 
     init(input: Binding<String>) {
         _input = input
         _suggestions = .init(T.descriptor(.valueContains(input.wrappedValue)))
+    }
+}
+
+private extension SuggestionButtons {
+    var suggestionButtonRow: some View {
+        HStack(spacing: SuggestionButtonsLayout.buttonSpacing) {
+            ForEach(suggestions) { suggestion in
+                Button(suggestion.value) {
+                    input = suggestion.value
+                }
+                .buttonStyle(.plain)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .padding(
+                    .horizontal,
+                    SuggestionButtonsLayout.buttonHorizontalPadding
+                )
+                .padding(
+                    .vertical,
+                    SuggestionButtonsLayout.buttonVerticalPadding
+                )
+                .cookleGlassControl(
+                    in: Capsule(style: .continuous)
+                )
+            }
+        }
     }
 }
 

--- a/Cookle/Sources/Recipe/Components/SuggestionButtonsLayout.swift
+++ b/Cookle/Sources/Recipe/Components/SuggestionButtonsLayout.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+enum SuggestionButtonsLayout {
+    static let buttonHorizontalPadding: CGFloat = 12
+    static let buttonSpacing: CGFloat = 8
+    static let buttonVerticalPadding: CGFloat = 7
+}

--- a/Cookle/Sources/Recipe/Views/AddMultipleTextsView.swift
+++ b/Cookle/Sources/Recipe/Views/AddMultipleTextsView.swift
@@ -16,6 +16,8 @@ struct AddMultipleTextsView: View {
 
     var body: some View {
         TextEditor(text: $text)
+            .accessibilityLabel(Text(title))
+            .accessibilityValue(Text(verbatim: text))
             .overlay(alignment: .topLeading) {
                 if text.isEmpty {
                     Text(placeholder)
@@ -32,6 +34,7 @@ struct AddMultipleTextsView: View {
                             RecipeTextEditorLayout.placeholderHorizontalPadding
                         )
                         .allowsHitTesting(false)
+                        .accessibilityHidden(true)
                 }
             }
             .padding()

--- a/Cookle/Sources/Recipe/Views/CookingSessionView.swift
+++ b/Cookle/Sources/Recipe/Views/CookingSessionView.swift
@@ -87,7 +87,7 @@ private extension CookingSessionView {
                 ) {
                     cookingSessionStore.endSession()
                 }
-                .buttonStyle(.borderedProminent)
+                .cookleGlassButtonStyle(isProminent: true)
             }
             .padding(Layout.screenPadding)
         }
@@ -164,8 +164,7 @@ private extension CookingSessionView {
             .padding(Layout.sectionPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(
-            .background,
+        .cookleGlassSurface(
             in: RoundedRectangle(
                 cornerRadius: Layout.sectionCornerRadius,
                 style: .continuous
@@ -202,13 +201,13 @@ private extension CookingSessionView {
         Button("Previous Step") {
             cookingSessionStore.returnToPreviousStep()
         }
-        .buttonStyle(.bordered)
+        .cookleGlassButtonStyle()
         .disabled(snapshot.hasPreviousStep == false)
 
         Button("Next Step") {
             cookingSessionStore.advanceToNextStep()
         }
-        .buttonStyle(.borderedProminent)
+        .cookleGlassButtonStyle(isProminent: true)
         .disabled(snapshot.hasNextStep == false)
     }
 
@@ -217,8 +216,7 @@ private extension CookingSessionView {
     ) -> some View {
         content()
             .padding(Layout.sectionPadding)
-            .background(
-                .background,
+            .cookleGlassSurface(
                 in: RoundedRectangle(
                     cornerRadius: Layout.sectionCornerRadius,
                     style: .continuous

--- a/Cookle/Sources/Recipe/Views/InferRecipeFormView.swift
+++ b/Cookle/Sources/Recipe/Views/InferRecipeFormView.swift
@@ -34,6 +34,8 @@ struct InferRecipeFormView: View {
 
     var body: some View {
         TextEditor(text: $text)
+            .accessibilityLabel(Text("Recipe Text"))
+            .accessibilityValue(Text(verbatim: text))
             .overlay(alignment: .topLeading) {
                 placeholderOverlay
             }
@@ -93,6 +95,7 @@ struct InferRecipeFormView: View {
                     RecipeTextEditorLayout.placeholderHorizontalPadding
                 )
                 .allowsHitTesting(false)
+                .accessibilityHidden(true)
         }
     }
 

--- a/Cookle/Sources/Search/Views/CookleSearchField.swift
+++ b/Cookle/Sources/Search/Views/CookleSearchField.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct CookleSearchField: View {
+    private enum Layout {
+        static let spacing: CGFloat = 8
+        static let horizontalPadding: CGFloat = 12
+        static let verticalPadding: CGFloat = 10
+        static let cornerRadius: CGFloat = 12
+    }
+
+    @Binding private var text: String
+
+    private let isFocused: FocusState<Bool>.Binding
+
+    var body: some View {
+        HStack(spacing: Layout.spacing) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            TextField("Search", text: $text, prompt: Text("Search"))
+                .focused(isFocused)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text("Clear Search"))
+            }
+        }
+        .padding(.horizontal, Layout.horizontalPadding)
+        .padding(.vertical, Layout.verticalPadding)
+        .background(
+            Color(.secondarySystemFill),
+            in: .rect(
+                cornerRadius: Layout.cornerRadius,
+                style: .continuous
+            )
+        )
+    }
+
+    init(
+        text: Binding<String>,
+        isFocused: FocusState<Bool>.Binding
+    ) {
+        _text = text
+        self.isFocused = isFocused
+    }
+}
+
+#Preview {
+    @Previewable @State var text = "Carbonara"
+    @FocusState var isFocused: Bool
+
+    CookleSearchField(
+        text: $text,
+        isFocused: $isFocused
+    )
+    .padding()
+}

--- a/Cookle/Sources/Search/Views/CookleSearchField.swift
+++ b/Cookle/Sources/Search/Views/CookleSearchField.swift
@@ -37,9 +37,8 @@ struct CookleSearchField: View {
         }
         .padding(.horizontal, Layout.horizontalPadding)
         .padding(.vertical, Layout.verticalPadding)
-        .background(
-            Color(.secondarySystemFill),
-            in: .rect(
+        .cookleGlassControl(
+            in: RoundedRectangle(
                 cornerRadius: Layout.cornerRadius,
                 style: .continuous
             )

--- a/Cookle/Sources/Search/Views/SearchView.swift
+++ b/Cookle/Sources/Search/Views/SearchView.swift
@@ -9,6 +9,10 @@ import SwiftData
 import SwiftUI
 
 struct SearchView: View {
+    private enum Layout {
+        static let searchFieldVerticalPadding: CGFloat = 8
+    }
+
     private enum DiscoverySheet: String, Identifiable {
         case ingredient
         case category
@@ -28,23 +32,26 @@ struct SearchView: View {
 
     @State private var recipes = [Recipe]()
     @State private var searchText = ""
-    @State private var isFocused = false
     @State private var discoverySheet: DiscoverySheet?
     @State private var ingredientSelection: Ingredient?
     @State private var categorySelection: Category?
     @State private var discoveryRecipeSelection: Recipe?
+    @FocusState private var isSearchFocused: Bool
 
     var body: some View {
-        Group {
-            if !recipes.isEmpty {
-                searchResults
-            } else if !searchText.isEmpty {
-                notFoundPlaceholder
-            } else {
-                searchPromptPlaceholder
-            }
+        VStack(spacing: 0) {
+            CookleSearchField(
+                text: $searchText,
+                isFocused: $isSearchFocused
+            )
+            .padding(.horizontal)
+            .padding(.vertical, Layout.searchFieldVerticalPadding)
+
+            Divider()
+
+            searchContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .searchable(text: $searchText, isPresented: $isFocused)
         .cookleTopLevelNavigationChrome(
             "Search",
             keyboardDismissMode: .immediately
@@ -87,6 +94,16 @@ struct SearchView: View {
         }
     }
 
+    @ViewBuilder var searchContent: some View {
+        if !recipes.isEmpty {
+            searchResults
+        } else if !searchText.isEmpty {
+            notFoundPlaceholder
+        } else {
+            searchPromptPlaceholder
+        }
+    }
+
     var searchResults: some View {
         List(recipes) { rowRecipe in
             Button {
@@ -114,7 +131,7 @@ struct SearchView: View {
             Text("Search by recipe name, ingredient, or category.")
         } actions: {
             Button("Start Searching") {
-                isFocused = true
+                isSearchFocused = true
             }
             Button("Ingredient") {
                 discoverySheet = .ingredient
@@ -153,12 +170,17 @@ private extension SearchView {
             return
         }
         searchText = incomingSearchQuery
-        isFocused = true
+        isSearchFocused = true
         self.incomingSearchQuery = nil
         performSearch()
     }
 
     func performSearch() {
+        guard !searchText.isEmpty else {
+            recipes = []
+            return
+        }
+
         do {
             recipes = try RecipeOperations.search(
                 context: context,

--- a/Cookle/Sources/Search/Views/SearchView.swift
+++ b/Cookle/Sources/Search/Views/SearchView.swift
@@ -134,8 +134,7 @@ struct SearchView: View {
                 discoverySheet = .category
             }
         } label: {
-            Image(systemName: "line.3.horizontal.decrease.circle")
-                .accessibilityLabel("Browse Tags")
+            Label("Browse Tags", systemImage: "line.3.horizontal.decrease.circle")
         }
     }
 

--- a/Cookle/Sources/Settings/Views/SettingsSidebarView.swift
+++ b/Cookle/Sources/Settings/Views/SettingsSidebarView.swift
@@ -12,6 +12,10 @@ import TipKit
 import UIKit
 
 struct SettingsSidebarView: View {
+    private enum Layout {
+        static let bottomContentMargin: CGFloat = 96
+    }
+
     @State private var model = SettingsScreenModel()
     @State private var isDebugPresented = false
 
@@ -132,6 +136,11 @@ struct SettingsSidebarView: View {
                 )
             )
         }
+        .contentMargins(
+            .bottom,
+            Layout.bottomContentMargin,
+            for: .scrollContent
+        )
     }
 
     @ViewBuilder var subscriptionSection: some View {

--- a/Cookle/Sources/Tag/Views/TagFormView.swift
+++ b/Cookle/Sources/Tag/Views/TagFormView.swift
@@ -19,9 +19,7 @@ struct TagFormView<T: Tag>: View {
     var body: some View {
         Form {
             Section {
-                TextField(text: $value) {
-                    Text("Spaghetti")
-                }
+                TextField("Value", text: $value, prompt: Text("Spaghetti"))
             } header: {
                 Text("Value")
             }

--- a/Cookle/Sources/Tag/Views/TagListView.swift
+++ b/Cookle/Sources/Tag/Views/TagListView.swift
@@ -9,6 +9,8 @@ import SwiftData
 import SwiftUI
 
 struct TagListView<T: Tag>: View {
+    private let searchFieldVerticalPadding: CGFloat = 8
+
     @Environment(\.isPresented)
     private var isPresented
 
@@ -18,20 +20,33 @@ struct TagListView<T: Tag>: View {
     @Binding private var tag: T?
 
     @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
 
     var body: some View {
-        contentView
-            .cookleTopLevelNavigationChrome(T.title)
-            .toolbar {
-                ToolbarItem {
-                    AddRecipeButton()
-                }
-                ToolbarItem {
-                    if isPresented {
-                        CloseButton()
-                    }
+        VStack(spacing: 0) {
+            CookleSearchField(
+                text: $searchText,
+                isFocused: $isSearchFocused
+            )
+            .padding(.horizontal)
+            .padding(.vertical, searchFieldVerticalPadding)
+
+            Divider()
+
+            contentView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .cookleTopLevelNavigationChrome(T.title)
+        .toolbar {
+            ToolbarItem {
+                AddRecipeButton()
+            }
+            ToolbarItem {
+                if isPresented {
+                    CloseButton()
                 }
             }
+        }
     }
 
     init(selection: Binding<T?> = .constant(nil)) {
@@ -52,21 +67,24 @@ private extension TagListView {
         List(filteredTags) { rowTag in
             tagRow(for: rowTag)
         }
-        .searchable(text: $searchText)
     }
 
-    var emptyStateView: some View {
-        ContentUnavailableView {
-            Label {
-                Text(T.title)
-            } icon: {
-                Image(systemName: "tag")
-                    .accessibilityHidden(true)
+    @ViewBuilder var emptyStateView: some View {
+        if !tags.isEmpty {
+            ContentUnavailableView.search(text: searchText)
+        } else {
+            ContentUnavailableView {
+                Label {
+                    Text(T.title)
+                } icon: {
+                    Image(systemName: "tag")
+                        .accessibilityHidden(true)
+                }
+            } description: {
+                Text("Tags appear after recipes create them.")
+            } actions: {
+                AddRecipeButton()
             }
-        } description: {
-            Text("Tags appear after recipes create them.")
-        } actions: {
-            AddRecipeButton()
         }
     }
 

--- a/CookleLibrary/Sources/Recipe/RecipeFormIngredientInput.swift
+++ b/CookleLibrary/Sources/Recipe/RecipeFormIngredientInput.swift
@@ -1,5 +1,5 @@
 /// Ingredient input used in recipe form flows.
-public struct RecipeFormIngredientInput: Sendable {
+public struct RecipeFormIngredientInput: Equatable, Sendable {
     public var ingredient: String
     public var amount: String
 


### PR DESCRIPTION
## Summary

- Add reusable Liquid Glass-style surface, control, and button treatments with fallbacks for older OS versions.
- Replace system searchable placements with visible Cookle search fields in the main search flow, tag browsing, and diary recipe picker.
- Improve recipe form row identity, photo removal handling, and editable field accessibility labels/prompts.
- Polish suggestion buttons, cooking session presentation, settings spacing, and localized strings touched by the UI refresh.

## Impact

This keeps Cookle's existing tab-based experience intact while moving the visible SwiftUI surfaces toward a more modern Apple-aligned treatment. The form and search updates also reduce state/identity risk and make controls clearer for accessibility.

## Validation

- `bash ci_scripts/tasks/check_repository_rules.sh`
- `git diff --check`
- XcodeBuildMCP `build_sim` for `Cookle`
- XcodeBuildMCP `test_sim` for `CookleLibrary` (203 passed)
- XcodeBuildMCP `build_run_sim` for `Cookle`
- XcodeBuildMCP screenshot capture on iPhone 17 Pro Simulator

Note: semantic UI hierarchy capture with XcodeBuildMCP `snapshot_ui` is currently blocked in this local environment because the selected `/Applications/Xcode-beta.app` is missing `Library/PrivateFrameworks/SimulatorKit.framework`.