### PR TITLE
[codex] Adopt MHUI app styling

### DIFF
--- a/Cookle.xcodeproj/project.pbxproj
+++ b/Cookle.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		AD2781342E844E0400B4AC19 /* CookleLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = AD2781332E844E0400B4AC19 /* CookleLibrary */; };
 		AD51C0012FA3000000000001 /* CookleLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = AD51C0002FA3000000000001 /* CookleLibrary */; };
 		AD7F5C0E2F5B3186008D91F3 /* MHPlatform in Frameworks */ = {isa = PBXBuildFile; productRef = AD7F5C0D2F5B3186008D91F3 /* MHPlatform */; };
-		ADB8BF9D2F8FE0DF00C59D93 /* MHDesign in Frameworks */ = {isa = PBXBuildFile; productRef = ADB8BF9C2F8FE0DF00C59D93 /* MHDesign */; };
+		ADB8BF9D2F8FE0DF00C59D93 /* MHUI in Frameworks */ = {isa = PBXBuildFile; productRef = ADB8BF9C2F8FE0DF00C59D93 /* MHUI */; };
 		ADB8C6262F9293B700C59D93 /* Watch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = ADB8C61C2F9293B500C59D93 /* Watch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		ADF13D702E8233A7002572CD /* CookleLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = ADF13D6F2E8233A7002572CD /* CookleLibrary */; };
 /* End PBXBuildFile section */
@@ -109,7 +109,7 @@
 			files = (
 				AD7F5C0E2F5B3186008D91F3 /* MHPlatform in Frameworks */,
 				ADF13D702E8233A7002572CD /* CookleLibrary in Frameworks */,
-				ADB8BF9D2F8FE0DF00C59D93 /* MHDesign in Frameworks */,
+				ADB8BF9D2F8FE0DF00C59D93 /* MHUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -204,7 +204,7 @@
 			packageProductDependencies = (
 				AD7F5C0D2F5B3186008D91F3 /* MHPlatform */,
 				ADF13D6F2E8233A7002572CD /* CookleLibrary */,
-				ADB8BF9C2F8FE0DF00C59D93 /* MHDesign */,
+				ADB8BF9C2F8FE0DF00C59D93 /* MHUI */,
 			);
 			productName = Cookle;
 			productReference = AD8C8E682BFABEE200872BF2 /* Cookle.app */;
@@ -779,10 +779,10 @@
 			package = AD7F5C0F2F5B3186008D91F3 /* XCRemoteSwiftPackageReference "MHPlatform" */;
 			productName = MHPlatform;
 		};
-		ADB8BF9C2F8FE0DF00C59D93 /* MHDesign */ = {
+		ADB8BF9C2F8FE0DF00C59D93 /* MHUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = ADB8BF9B2F8FE0DF00C59D93 /* XCRemoteSwiftPackageReference "MHUI" */;
-			productName = MHDesign;
+			productName = MHUI;
 		};
 		ADF13D6F2E8233A7002572CD /* CookleLibrary */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cookle/Sources/App/CookleApp.swift
+++ b/Cookle/Sources/App/CookleApp.swift
@@ -6,6 +6,7 @@
 //
 
 import MHPlatform
+import MHUI
 import SwiftUI
 
 @main
@@ -32,6 +33,7 @@ struct CookleApp: App {
                     )
                 }
             }
+            .mhTheme(.standard())
             .task(id: isICloudOn) {
                 await bootstrapModel.loadAssembly(
                     isICloudOn: isICloudOn

--- a/Cookle/Sources/Features/Debug/Views/DebugContentView.swift
+++ b/Cookle/Sources/Features/Debug/Views/DebugContentView.swift
@@ -26,6 +26,7 @@ struct DebugContentView<Model: PersistentModel>: View {
                 }
             }
         }
+        .cookleListChrome()
         .navigationTitle(Text("Content"))
     }
 

--- a/Cookle/Sources/Features/Debug/Views/DebugPreviewsView.swift
+++ b/Cookle/Sources/Features/Debug/Views/DebugPreviewsView.swift
@@ -19,6 +19,7 @@ struct DebugPreviewsView: View {
             AdvertisementSection(.small)
             ShortcutsLinkSection()
         }
+        .cookleListChrome()
         .navigationTitle(Text("Previews"))
     }
 }

--- a/Cookle/Sources/Features/Diary/Views/DiaryFormRecipeListView.swift
+++ b/Cookle/Sources/Features/Diary/Views/DiaryFormRecipeListView.swift
@@ -26,6 +26,7 @@ struct DiaryFormRecipeListView: View {
     var body: some View {
         contentView
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .cookleListChrome()
             .environment(\.editMode, .constant(.active))
             .navigationTitle(type.title)
             .searchable(

--- a/Cookle/Sources/Features/Diary/Views/DiaryFormView.swift
+++ b/Cookle/Sources/Features/Diary/Views/DiaryFormView.swift
@@ -34,6 +34,7 @@ struct DiaryFormView: View {
             mealSection(type: .dinner, recipes: $model.dinners)
             noteSection
         }
+        .cookleFormChrome()
         .disabled(model.isSaving)
         .navigationDestination(for: DiaryObjectType.self) { type in
             destinationView(for: type)

--- a/Cookle/Sources/Features/Diary/Views/DiaryObjectView.swift
+++ b/Cookle/Sources/Features/Diary/Views/DiaryObjectView.swift
@@ -38,6 +38,7 @@ struct DiaryObjectView: View {
                 Text("Updated At")
             }
         }
+        .cookleListChrome()
     }
 }
 

--- a/Cookle/Sources/Features/Diary/Views/DiaryView.swift
+++ b/Cookle/Sources/Features/Diary/Views/DiaryView.swift
@@ -22,6 +22,7 @@ struct DiaryView: View {
             updatedAtSection
             actionSection
         }
+        .cookleListChrome()
         .navigationTitle(diary.date.formatted(.dateTime.year().month().day().weekday()))
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {

--- a/Cookle/Sources/Features/Photo/Views/PhotoObjectView.swift
+++ b/Cookle/Sources/Features/Photo/Views/PhotoObjectView.swift
@@ -13,6 +13,7 @@ struct PhotoObjectView: View {
             createdAtSection
             updatedAtSection
         }
+        .cookleListChrome()
     }
 
     var photoSection: some View {

--- a/Cookle/Sources/Features/Photo/Views/PhotoView.swift
+++ b/Cookle/Sources/Features/Photo/Views/PhotoView.swift
@@ -29,6 +29,7 @@ struct PhotoView: View {
             updatedAtSection
             actionSection
         }
+        .cookleListChrome()
         .navigationTitle(
             PhotoDisplayCopy.title(for: photo)
         )

--- a/Cookle/Sources/Features/Recipe/Components/CookingSessionTimerSection.swift
+++ b/Cookle/Sources/Features/Recipe/Components/CookingSessionTimerSection.swift
@@ -209,7 +209,7 @@ private extension CookingSessionTimerSection {
             ) {
                 cookingSessionStore.cancelTimer()
             }
-            .cookleGlassButtonStyle()
+            .cookleDestructiveButtonStyle()
         }
     }
 

--- a/Cookle/Sources/Features/Recipe/Components/RecipeForm/RecipeFormPhotosSection.swift
+++ b/Cookle/Sources/Features/Recipe/Components/RecipeForm/RecipeFormPhotosSection.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MHDesign
+import MHUI
 import PhotosUI
 import SwiftData
 import SwiftUI

--- a/Cookle/Sources/Features/Recipe/Models/RecipeTextEditorLayout.swift
+++ b/Cookle/Sources/Features/Recipe/Models/RecipeTextEditorLayout.swift
@@ -1,5 +1,5 @@
 import CoreGraphics
-import MHDesign
+import MHUI
 
 enum RecipeTextEditorLayout {
     static let placeholderHorizontalPadding: CGFloat = 6

--- a/Cookle/Sources/Features/Recipe/Views/AddMultipleTextsView.swift
+++ b/Cookle/Sources/Features/Recipe/Views/AddMultipleTextsView.swift
@@ -1,4 +1,4 @@
-import MHDesign
+import MHUI
 import SwiftUI
 
 struct AddMultipleTextsView: View {
@@ -39,16 +39,9 @@ struct AddMultipleTextsView: View {
             }
             .padding()
             .scrollContentBackground(.hidden)
-            .background(Color(.secondarySystemGroupedBackground))
-            .clipShape(
-                .rect(
-                    cornerRadius: RecipeTextEditorLayout.cornerRadius(
-                        metrics: designMetrics
-                    )
-                )
-            )
+            .mhInputChrome()
             .padding()
-            .background(Color(.systemGroupedBackground))
+            .cookleScreenChrome()
             .navigationTitle(title)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/Cookle/Sources/Features/Recipe/Views/CookingSessionView.swift
+++ b/Cookle/Sources/Features/Recipe/Views/CookingSessionView.swift
@@ -87,11 +87,11 @@ private extension CookingSessionView {
                 ) {
                     cookingSessionStore.endSession()
                 }
-                .cookleGlassButtonStyle(isProminent: true)
+                .cookleDestructiveButtonStyle()
             }
             .padding(Layout.screenPadding)
         }
-        .background(Color(.systemGroupedBackground))
+        .cookleScreenChrome()
         .navigationTitle(snapshot.recipeName)
     }
 

--- a/Cookle/Sources/Features/Recipe/Views/InferRecipeFormView.swift
+++ b/Cookle/Sources/Features/Recipe/Views/InferRecipeFormView.swift
@@ -1,5 +1,5 @@
 import AppIntents
-import MHDesign
+import MHUI
 import PhotosUI
 import SwiftUI
 
@@ -47,16 +47,9 @@ struct InferRecipeFormView: View {
             }
             .padding()
             .scrollContentBackground(.hidden)
-            .background(Color(.secondarySystemGroupedBackground))
-            .clipShape(
-                .rect(
-                    cornerRadius: RecipeTextEditorLayout.cornerRadius(
-                        metrics: designMetrics
-                    )
-                )
-            )
+            .mhInputChrome()
             .padding()
-            .background(Color(.systemGroupedBackground))
+            .cookleScreenChrome()
             .navigationTitle(Text("Recipe Text"))
             .toolbar {
                 toolbarItems

--- a/Cookle/Sources/Features/Recipe/Views/RecipeFormView.swift
+++ b/Cookle/Sources/Features/Recipe/Views/RecipeFormView.swift
@@ -44,6 +44,7 @@ struct RecipeFormView: View {
         Form {
             formSections
         }
+        .cookleFormChrome()
         .disabled(model.isSaving)
         .environment(\.editMode, $editMode)
         .navigationTitle(editMode == .inactive ? Text("Recipe") : Text("Editing..."))

--- a/Cookle/Sources/Features/Recipe/Views/RecipeView.swift
+++ b/Cookle/Sources/Features/Recipe/Views/RecipeView.swift
@@ -28,6 +28,7 @@ struct RecipeView: View {
             recipeSections
             recipeActionSection
         }
+        .cookleListChrome()
         .navigationTitle(recipe.name)
         .cookleIdleTimerDisabled()
         .fullScreenCover(isPresented: $isCookingPresented) {

--- a/Cookle/Sources/Features/Settings/Views/LicenseList/LicenseView.swift
+++ b/Cookle/Sources/Features/Settings/Views/LicenseList/LicenseView.swift
@@ -7,6 +7,7 @@ struct LicenseView: View {
 
     var body: some View {
         appRuntime.licensesView()
+            .cookleListChrome()
             .navigationTitle(Text("Licenses"))
     }
 }

--- a/Cookle/Sources/Features/Settings/Views/StoreKit/StoreListView.swift
+++ b/Cookle/Sources/Features/Settings/Views/StoreKit/StoreListView.swift
@@ -9,6 +9,7 @@ struct StoreListView: View {
         List {
             appRuntime.subscriptionSectionView()
         }
+        .cookleListChrome()
         .navigationTitle(Text("Subscription"))
     }
 }

--- a/Cookle/Sources/Features/Tag/Views/IngredientObjectView.swift
+++ b/Cookle/Sources/Features/Tag/Views/IngredientObjectView.swift
@@ -38,6 +38,7 @@ struct IngredientObjectView: View {
                 Text("Updated At")
             }
         }
+        .cookleListChrome()
     }
 }
 

--- a/Cookle/Sources/Features/Tag/Views/TagFormView.swift
+++ b/Cookle/Sources/Features/Tag/Views/TagFormView.swift
@@ -36,6 +36,7 @@ struct TagFormView<T: Tag>: View {
                 Text("Recipes")
             }
         }
+        .cookleFormChrome()
         .navigationTitle("Edit " + tag.value)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {

--- a/Cookle/Sources/Features/Tag/Views/TagView.swift
+++ b/Cookle/Sources/Features/Tag/Views/TagView.swift
@@ -22,6 +22,7 @@ struct TagView<T: Tag>: View {
             updatedAtSection
             actionSection
         }
+        .cookleListChrome()
         .navigationTitle(tag.value)
         .toolbar {
             ToolbarItem {

--- a/Cookle/Sources/SharedUI/Components/AdvertisementSection.swift
+++ b/Cookle/Sources/SharedUI/Components/AdvertisementSection.swift
@@ -5,8 +5,8 @@
 //  Created by Hiromu Nakano on 2022/01/17.
 //
 
-import MHDesign
 import MHPlatform
+import MHUI
 import SwiftUI
 
 struct AdvertisementSection {

--- a/Cookle/Sources/SharedUI/Styles/CookleGlassButtonStyleModifier.swift
+++ b/Cookle/Sources/SharedUI/Styles/CookleGlassButtonStyleModifier.swift
@@ -1,3 +1,4 @@
+import MHUI
 import SwiftUI
 
 struct CookleGlassButtonStyleModifier: ViewModifier {
@@ -5,16 +6,10 @@ struct CookleGlassButtonStyleModifier: ViewModifier {
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            if isProminent {
-                content.buttonStyle(.glassProminent)
-            } else {
-                content.buttonStyle(.glass)
-            }
-        } else if isProminent {
-            content.buttonStyle(.borderedProminent)
+        if isProminent {
+            content.buttonStyle(.mhPrimary)
         } else {
-            content.buttonStyle(.bordered)
+            content.buttonStyle(.mhSecondary)
         }
     }
 }

--- a/Cookle/Sources/SharedUI/Styles/CookleGlassControlModifier.swift
+++ b/Cookle/Sources/SharedUI/Styles/CookleGlassControlModifier.swift
@@ -1,21 +1,19 @@
+import MHUI
 import SwiftUI
 
 struct CookleGlassControlModifier<S: Shape>: ViewModifier {
     let shape: S
     let isInteractive: Bool
 
-    @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            content.glassEffect(
-                .regular.interactive(isInteractive),
-                in: shape
-            )
+        if isInteractive {
+            content
+                .mhSurface()
+                .clipShape(shape)
         } else {
-            content.background(
-                .thinMaterial,
-                in: shape
-            )
+            content
+                .mhSurface(role: .muted)
+                .clipShape(shape)
         }
     }
 }

--- a/Cookle/Sources/SharedUI/Styles/CookleGlassSurfaceModifier.swift
+++ b/Cookle/Sources/SharedUI/Styles/CookleGlassSurfaceModifier.swift
@@ -1,20 +1,12 @@
+import MHUI
 import SwiftUI
 
 struct CookleGlassSurfaceModifier<S: Shape>: ViewModifier {
     let shape: S
 
-    @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            content.glassEffect(
-                .regular,
-                in: shape
-            )
-        } else {
-            content.background(
-                .background,
-                in: shape
-            )
-        }
+        content
+            .mhSurface()
+            .clipShape(shape)
     }
 }

--- a/Cookle/Sources/SharedUI/Styles/CookleTopLevelNavigationChromeModifier.swift
+++ b/Cookle/Sources/SharedUI/Styles/CookleTopLevelNavigationChromeModifier.swift
@@ -1,3 +1,4 @@
+import MHUI
 import SwiftUI
 
 struct CookleTopLevelNavigationChromeModifier: ViewModifier {
@@ -6,6 +7,7 @@ struct CookleTopLevelNavigationChromeModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .cookleListChrome()
             .navigationTitle(title)
             .toolbarRole(.editor)
             .modifier(

--- a/Cookle/Sources/SharedUI/Support/View+CookleContainerChrome.swift
+++ b/Cookle/Sources/SharedUI/Support/View+CookleContainerChrome.swift
@@ -1,0 +1,16 @@
+import MHUI
+import SwiftUI
+
+extension View {
+    func cookleListChrome() -> some View {
+        mhListChrome()
+    }
+
+    func cookleFormChrome() -> some View {
+        mhFormChrome()
+    }
+
+    func cookleScreenChrome() -> some View {
+        mhScreen()
+    }
+}

--- a/Cookle/Sources/SharedUI/Support/View+CookleGlassButtonStyle.swift
+++ b/Cookle/Sources/SharedUI/Support/View+CookleGlassButtonStyle.swift
@@ -1,3 +1,4 @@
+import MHUI
 import SwiftUI
 
 extension View {
@@ -7,5 +8,9 @@ extension View {
                 isProminent: isProminent
             )
         )
+    }
+
+    func cookleDestructiveButtonStyle() -> some View {
+        buttonStyle(.mhDestructive)
     }
 }

--- a/Designs/Architecture/ARCHITECTURE_GUIDE.md
+++ b/Designs/Architecture/ARCHITECTURE_GUIDE.md
@@ -65,9 +65,9 @@ symmetry with sibling apps.
 - `CookleLibrary` adopts `MHPlatformCore` for core-safe route, preference,
   persistence-maintenance, and logging contracts. It must not depend on
   `MHPlatform`, `MHAppRuntime`, app-runtime split products, MHUI, or MHDesign.
-- `Cookle` adopts `MHDesign` as a metrics-only MHUI dependency for shared
-  spacing and corner-radius values. Cookle does not link the full `MHUI`
-  product until it intentionally adopts package-owned styled primitives.
+- `Cookle` adopts the full `MHUI` styled surface for app-owned SwiftUI
+  presentation chrome, semantic theme, shared metrics, and package-owned
+  styled primitives.
 - `Widgets`, `Watch`, and App Intents call Cookle shared APIs first. They stay
   off app-runtime and presentation package umbrellas by default.
 - Cookle does not keep a generic utility package dependency. Small app-owned

--- a/Designs/Architecture/shared-service-design.md
+++ b/Designs/Architecture/shared-service-design.md
@@ -74,8 +74,9 @@ that use case.
   app-runtime umbrella adoption.
 - This repository intentionally uses the MHPlatform 1.x semver range
   `1.0.0..<2.0.0` with a checked-in `1.9+` resolved baseline.
-- `Cookle` adopts `MHDesign` from MHUI as a metrics-only presentation
-  dependency for shared spacing and radius values.
+- `Cookle` adopts the full `MHUI` styled surface for app-owned SwiftUI
+  presentation chrome, semantic theme, shared metrics, and package-owned
+  styled primitives.
 - `CookleLibrary` stays presentation-free and must not depend on MHUI or
   MHDesign.
 - `Widgets` and `Watch` stay off MHUI and MHDesign by default; they should call

--- a/Designs/Decisions/0008-adopt-package-consumer-boundaries.md
+++ b/Designs/Decisions/0008-adopt-package-consumer-boundaries.md
@@ -29,10 +29,8 @@ package-surface parity.
 - `Cookle` remains the full-app `MHPlatform` adopter.
 - `CookleLibrary` remains on `MHPlatformCore` and stays off `MHPlatform`,
   `MHAppRuntime`, app-runtime split products, MHUI, and MHDesign.
-- `Cookle` links `MHDesign` as a metrics-only dependency for shared spacing and
-  radius values.
-- `Cookle` does not link the full `MHUI` product until the app intentionally
-  adopts package-owned styled primitives.
+- `Cookle` links the full `MHUI` product for app-owned SwiftUI presentation
+  chrome, semantic theme, shared metrics, and package-owned styled primitives.
 - `Widgets`, `Watch`, and App Intents call `CookleLibrary` APIs first and stay
   off app-runtime and presentation package umbrellas by default.
 - Cookle does not keep a generic utility package dependency. Generic helpers
@@ -49,7 +47,8 @@ Shared package updates should be evaluated by responsibility:
 
 - platform runtime and app composition concerns belong in the app target
 - reusable business behavior belongs behind `CookleLibrary` Operations facades
-- shared visual metrics can come from `MHDesign`
+- app-owned SwiftUI presentation can use `MHUI` styled primitives and its
+  `MHDesign` re-export
 - Cookle-specific screen composition stays in Cookle views and screen models
 - generic helpers stay app/shared-library-owned unless they become a stable
   platform-foundation contract

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ repository contains the full iOS project together with its shared Swift package.
   intentionally adopts the default `MHPlatform` umbrella surface, while
   `CookleLibrary` stays on `MHPlatformCore` for core-safe shared logic.
 - `MHUI` / `MHDesign` – shared presentation package family. `Cookle` adopts
-  `MHDesign` as a metrics-only dependency for shared spacing and radius values,
-  while product-specific screen composition stays in the app target.
+  the full `MHUI` styled surface for app-owned SwiftUI presentation, while
+  product-specific screen composition stays in the app target.
 - `Designs/Architecture/` – current architecture rules and placement guidance.
 - `Designs/Decisions/` – architecture decision records that capture why major
   design choices were made.
@@ -74,9 +74,8 @@ repository contains the full iOS project together with its shared Swift package.
   stays on the default `MHPlatform` umbrella, `CookleLibrary` stays on
   `MHPlatformCore`, and the repository keeps MHPlatform on the
   `1.0.0..<2.0.0` range with a checked-in `1.9+` resolved baseline.
-- MHUI 1.x through the `MHDesign` product for metrics-only app presentation
-  adoption. The full `MHUI` chrome product is not linked unless Cookle
-  intentionally adopts package-owned styled primitives.
+- MHUI 1.x through the full `MHUI` product for app presentation chrome,
+  semantic theme, shared metrics, and package-owned styled primitives.
 - Cookle does not keep a generic utility package dependency. Small app-owned
   helper behavior stays local, while generic utilities and thin host-app
   presentation shortcuts remain outside MHUI.
@@ -102,9 +101,9 @@ Primary records:
 - MHPlatform consumer boundaries are explicit in this repo: `Cookle` is the
   umbrella-app adopter, `CookleLibrary` stays on `MHPlatformCore`, and
   `Widgets`/`Watch` stay off the umbrella.
-- MHUI consumer boundaries are explicit in this repo: `Cookle` currently adopts
-  `MHDesign` for shared metrics only, `CookleLibrary` stays presentation-free,
-  and `Widgets`/`Watch` call app shared APIs before adding presentation package
+- MHUI consumer boundaries are explicit in this repo: `Cookle` adopts the full
+  `MHUI` styled surface, `CookleLibrary` stays presentation-free, and
+  `Widgets`/`Watch` call app shared APIs before adding presentation package
   dependencies.
 - `MHAppRuntime` remains available as an advanced app-root surface, but this
   repo does not use it as the default adoption path.

--- a/ci_scripts/tasks/check_package_consumer_boundaries.sh
+++ b/ci_scripts/tasks/check_package_consumer_boundaries.sh
@@ -21,7 +21,7 @@ shared_service_design="Designs/Architecture/shared-service-design.md"
 # Cookle follows current MHPlatform/MHUI consumer boundaries:
 # - Cookle is the full-app MHPlatform adopter.
 # - CookleLibrary uses MHPlatformCore and must stay off app runtime products.
-# - Cookle uses MHDesign as a metrics-only presentation dependency.
+# - Cookle uses the full MHUI styled surface for app-owned presentation.
 # - Shared logic and delivery-surface adapters stay off MHUI/MHDesign.
 
 declare -a errors=()
@@ -184,12 +184,12 @@ if ! grep -Eq '/\* MHPlatform \*/' <<<"$cookle_target_block"; then
   append_error "Cookle must keep the MHPlatform umbrella linked in $project_file."
 fi
 
-if ! grep -Eq '/\* MHDesign \*/' <<<"$cookle_target_block"; then
-  append_error "Cookle must keep the MHDesign metrics product linked in $project_file."
+if ! grep -Eq '/\* MHUI \*/' <<<"$cookle_target_block"; then
+  append_error "Cookle must keep the full MHUI styled product linked in $project_file."
 fi
 
-if grep -Eq '/\* MHUI \*/|productName = MHUI;' <<<"$cookle_target_block"; then
-  append_error "Cookle currently uses MHDesign as a metrics-only adopter and must not link the full MHUI product."
+if grep -Eq '/\* MHDesign \*/|productName = MHDesign;' <<<"$cookle_target_block"; then
+  append_error "Cookle uses the full MHUI styled product and must not link only MHDesign."
 fi
 
 if rg -nP '^\s*(?:@preconcurrency\s+)?import\s+MHPlatform\s*$' CookleLibrary/Sources CookleLibrary/Tests >/dev/null; then


### PR DESCRIPTION
## Summary

- Replace the Cookle app target's presentation dependency from `MHDesign` to the full `MHUI` product.
- Apply MHUI theme, list/form/screen chrome, input chrome, surface styling, and semantic button styles through Cookle-owned wrappers.
- Update package consumer boundary guardrails and architecture docs to reflect full MHUI app presentation adoption.

## Screenshots

Captured on iPhone 17 Pro simulator, iOS 27.0. Images are embedded from the PR screenshot asset branch `codex/pr-108-mhui-screenshots`.

<table>
  <tr>
    <td><strong>Diary list</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/01-diary-list.png" width="260"></td>
    <td><strong>Recipe list</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/02-recipe-list.png" width="260"></td>
  </tr>
  <tr>
    <td><strong>Photo list</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/03-photo-list.png" width="260"></td>
    <td><strong>Settings</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/04-settings.png" width="260"></td>
  </tr>
  <tr>
    <td><strong>Search</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/05-search.png" width="260"></td>
    <td><strong>Recipe detail</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/06-recipe-detail.png" width="260"></td>
  </tr>
  <tr>
    <td><strong>Recipe form</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/07-recipe-form.png" width="260"></td>
    <td><strong>Cooking session</strong><br><img src="https://raw.githubusercontent.com/muhiro12/Cookle/2ca631872ffcf65ea0849af8435af47488b2ac3c/08-cooking-session.png" width="260"></td>
  </tr>
</table>

## Verification

- Xcode `Cookle` scheme build
- Simulator install/run and screen capture pass
- crash/fatal/exception log scan found no app crash signature
- `bash ci_scripts/tasks/format_swift.sh`
- `bash ci_scripts/tasks/check_repository_rules.sh`
- `git diff --check`
